### PR TITLE
Use a binary search tree for sorting the beachline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,8 @@ test/fastjet/**
 test/voronoi++/**
 test/ivank/**
 test/shaneosullivan/**
+external
 
+.vscode
+**/.DS_Store
+tmp

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -7,7 +7,7 @@ if [ "$USE_ASAN" != "" ]; then
     ASAN_OPTIONS=detect_stack_use_after_return=1
     ASAN="-fsanitize=address -fno-omit-frame-pointer -fsanitize-address-use-after-scope -fsanitize=undefined"
     ASAN_LDFLAGS="-fsanitize=address "
-    OPT="-g -O1"
+    OPT="-g -O0"
     echo Using ASAN=${ASAN}
 fi
 
@@ -28,7 +28,9 @@ if [ "Darwin" == "$(uname)" ]; then
     fi
 fi
 
-CFLAGS="-g -O1 -Wall -Weverything -Wno-float-equal -pedantic -Wno-declaration-after-statement -Isrc"
+CFLAGS="-g -O2 -std=c11 -Wall -Weverything -Wno-double-promotion -Wno-float-equal -pedantic -Wno-declaration-after-statement -Isrc"
+DOUBLEDEFINES="-Wno-double-promotion -DTEST_USE_DOUBLE -DJCV_USE_DOUBLE=1 -DJCV_REAL_TYPE=double -DJCV_ATAN2=atan2 -DJCV_SQRT=sqrt -DJCV_REAL_TYPE_EPSILON=DBL_EPSILON"
+#CFLAGS="${CFLAGS} ${DOUBLEDEFINES}"
 
 ${CC} ${ASAN} ${ARCH} -c src/stb_wrapper.c -o build/stb_wrapper.o
 ${CC} ${ASAN} -o build/main ${ARCH} -std=${STDVERSION} ${OPT} ${CFLAGS} -lm  ${SYSROOT} build/stb_wrapper.o src/main.c

--- a/src/jc_voronoi.h
+++ b/src/jc_voronoi.h
@@ -922,7 +922,7 @@ static int jcv_pq_moveup(jcv_priorityqueue* pq, int pos)
     void* node = items[pos];
 
     for( int parent = (pos >> 1);
-         pos > 1 && pq->compare_fn(items[parent], node);
+         pos > 1 && pq->compare(items[parent], node);
          pos = parent, parent = parent >> 1)
     {
         items[pos] = items[parent];
@@ -940,7 +940,7 @@ static int jcv_pq_maxchild(jcv_priorityqueue* pq, int pos)
     if( child >= pq->numitems )
         return 0;
     void** items = pq->items;
-    if( (child + 1) < pq->numitems && pq->compare_fn(items[child], items[child+1]) )
+    if( (child + 1) < pq->numitems && pq->compare(items[child], items[child+1]) )
         return child+1;
     return child;
 }
@@ -951,7 +951,7 @@ static int jcv_pq_movedown(jcv_priorityqueue* pq, int pos)
     void* node = items[pos];
 
     int child = jcv_pq_maxchild(pq, pos);
-    while( child && pq->compare_fn(node, items[child]) )
+    while( child && pq->compare(node, items[child]) )
     {
         items[pos] = items[child];
         pq->set_pos(items[pos], pos);
@@ -964,11 +964,18 @@ static int jcv_pq_movedown(jcv_priorityqueue* pq, int pos)
     return pos;
 }
 
-static void jcv_pq_create(jcv_priorityqueue* pq, int capacity, void** buffer)
+static void jcv_pq_create(jcv_priorityqueue* pq, int capacity, void** buffer,
+                            FJCVPriorityQueueCompare compare_fn,
+                            FJCVPriorityQueueSetPos set_pos_fn,
+                            FJCVPriorityQueueGetPos get_pos_fn)
 {
     pq->maxnumitems = capacity;
     pq->numitems    = 1;
     pq->items       = buffer;
+
+    pq->compare = compare_fn;
+    pq->set_pos = set_pos_fn;
+    pq->get_pos = get_pos_fn;
 }
 
 static int jcv_pq_empty(jcv_priorityqueue* pq)
@@ -1008,7 +1015,7 @@ static void jcv_pq_remove(jcv_priorityqueue* pq, void* node)
     jcv_halfedge** items = (jcv_halfedge**)pq->items;
 
     items[pos] = items[--pq->numitems];
-    if( pq->compare_fn( node, items[pos] ) )
+    if( pq->compare( node, items[pos] ) )
         jcv_pq_moveup( pq, pos );
     else
         jcv_pq_movedown( pq, pos );
@@ -1572,7 +1579,12 @@ void jcv_diagram_generate_useralloc(int num_points, const jcv_point* points, con
     internal->last_inserted = 0;
 
     int max_num_events = num_points*2; // beachline can have max 2*n-5 parabolas
-    jcv_pq_create(internal->eventqueue, max_num_events, (void**)internal->eventmem);
+    jcv_priorityqueue* pq = internal->eventqueue;
+    jcv_pq_create(pq, max_num_events, (void**)internal->eventmem,
+                    (FJCVPriorityQueueCompare)jcv_event_compare,
+                    (FJCVPriorityQueueSetPos)jcv_event_set_pos,
+                    (FJCVPriorityQueueGetPos)jcv_event_get_pos);
+
 
     internal->numsites = num_points;
     jcv_site* sites = internal->sites;
@@ -1600,7 +1612,7 @@ void jcv_diagram_generate_useralloc(int num_points, const jcv_point* points, con
     tmp_rect.max.x = tmp_rect.max.y = -JCV_FLT_MAX;
     jcv_prune_duplicates(internal, &tmp_rect);
 
-    // Prune using the test second
+    // Prune using the test function
     if (internal->clipper.test_fn)
     {
         // e.g. used by the box clipper in the test_fn

--- a/src/jc_voronoi.h
+++ b/src/jc_voronoi.h
@@ -339,6 +339,28 @@ static inline jcv_real jcv_point_dist( const jcv_point* pt1, const jcv_point* pt
 
 #pragma pack(push, 1)
 
+typedef struct jcv_arc_
+{
+  struct jcv_arc_*  rb_parent;
+  struct jcv_arc_*  rb_left;
+  struct jcv_arc_*  rb_right;
+
+  jcv_site*             site;
+  jcv_edge*             edge;
+  struct jcv_event_*    circle_event;
+  uint8_t               is_leaf : 1;
+  uint8_t                       : 7;
+} jcv_arc;
+
+typedef struct jcv_event_
+{
+    jcv_arc*    arc;    // The associated parabola
+    jcv_point   p;
+    uint8_t     type    : 1; // 0: site event, 1: circle event
+    uint8_t     deleted : 1; // 1: the event has been discarded
+    uint8_t             : 6;
+} jcv_event;
+
 typedef struct jcv_halfedge_
 {
     jcv_edge*               edge;
@@ -360,12 +382,19 @@ typedef struct jcv_memoryblock_
 
 typedef int  (*FJCVPriorityQueuePrint)(const void* node, int pos);
 
+typedef int  (*FJCVPriorityQueueCompare)(const void* a, const void* b);
+typedef void (*FJCVPriorityQueueSetPos)(void* a, int pos);
+typedef int  (*FJCVPriorityQueueGetPos)(const void* a);
+
 typedef struct jcv_priorityqueue_
 {
     // Implements a binary heap
     int                         maxnumitems;
     int                         numitems;
     void**                      items;
+    FJCVPriorityQueueCompare    compare_fn;
+    FJCVPriorityQueueSetPos     set_pos;
+    FJCVPriorityQueueGetPos     get_pos;
 } jcv_priorityqueue;
 
 
@@ -837,6 +866,16 @@ static inline int jcv_halfedge_compare( const jcv_halfedge* he1, const jcv_halfe
 	return  (he1->y == he2->y) ? he1->vertex.x > he2->vertex.x : he1->y > he2->y;
 }
 
+static inline void jcv_halfedge_set_pos(jcv_halfedge* he, int pos )
+{
+	he->pqpos = pos;
+}
+
+static inline int jcv_halfedge_get_pos( const jcv_halfedge* he )
+{
+	return he->pqpos;
+}
+
 static int jcv_halfedge_intersect(const jcv_halfedge* he1, const jcv_halfedge* he2, jcv_point* out)
 {
     const jcv_edge* e1 = he1->edge;
@@ -877,18 +916,20 @@ static int jcv_halfedge_intersect(const jcv_halfedge* he1, const jcv_halfedge* h
 
 static int jcv_pq_moveup(jcv_priorityqueue* pq, int pos)
 {
-    jcv_halfedge** items = (jcv_halfedge**)pq->items;
-    jcv_halfedge* node = items[pos];
+    // jcv_halfedge** items = (jcv_halfedge**)pq->items;
+    // jcv_halfedge* node = items[pos];
+    void** items = pq->items;
+    void* node = items[pos];
 
     for( int parent = (pos >> 1);
-         pos > 1 && jcv_halfedge_compare(items[parent], node);
+         pos > 1 && pq->compare_fn(items[parent], node);
          pos = parent, parent = parent >> 1)
     {
         items[pos] = items[parent];
-        items[pos]->pqpos = pos;
+        pq->set_pos(items[pos], pos);
     }
 
-    node->pqpos = pos;
+    pq->set_pos(node, pos);
     items[pos] = node;
     return pos;
 }
@@ -898,28 +939,28 @@ static int jcv_pq_maxchild(jcv_priorityqueue* pq, int pos)
     int child = pos << 1;
     if( child >= pq->numitems )
         return 0;
-    jcv_halfedge** items = (jcv_halfedge**)pq->items;
-    if( (child + 1) < pq->numitems && jcv_halfedge_compare(items[child], items[child+1]) )
+    void** items = pq->items;
+    if( (child + 1) < pq->numitems && pq->compare_fn(items[child], items[child+1]) )
         return child+1;
     return child;
 }
 
 static int jcv_pq_movedown(jcv_priorityqueue* pq, int pos)
 {
-    jcv_halfedge** items = (jcv_halfedge**)pq->items;
-    jcv_halfedge* node = items[pos];
+    void** items = pq->items;
+    void* node = items[pos];
 
     int child = jcv_pq_maxchild(pq, pos);
-    while( child && jcv_halfedge_compare(node, items[child]) )
+    while( child && pq->compare_fn(node, items[child]) )
     {
         items[pos] = items[child];
-        items[pos]->pqpos = pos;
+        pq->set_pos(items[pos], pos);
         pos = child;
         child = jcv_pq_maxchild(pq, pos);
     }
 
     items[pos] = node;
-    items[pos]->pqpos = pos;
+    pq->set_pos(items[pos], pos);
     return pos;
 }
 
@@ -956,22 +997,22 @@ static void* jcv_pq_top(jcv_priorityqueue* pq)
     return pq->items[1];
 }
 
-static void jcv_pq_remove(jcv_priorityqueue* pq, jcv_halfedge* node)
+static void jcv_pq_remove(jcv_priorityqueue* pq, void* node)
 {
     if( pq->numitems == 1 )
         return;
-    int pos = node->pqpos;
+    int pos = pq->get_pos(node);
     if( pos == 0 )
         return;
 
     jcv_halfedge** items = (jcv_halfedge**)pq->items;
 
     items[pos] = items[--pq->numitems];
-    if( jcv_halfedge_compare( node, items[pos] ) )
+    if( pq->compare_fn( node, items[pos] ) )
         jcv_pq_moveup( pq, pos );
     else
         jcv_pq_movedown( pq, pos );
-    node->pqpos = pos;
+    pq->set_pos(node, pos);
 }
 
 // internal functions
@@ -1497,6 +1538,10 @@ static jcv_context_internal* jcv_alloc_internal(int num_points, void* userallocc
 
     mem = (char*)jcv_align(mem, sizeof(void*));
     internal->eventqueue = (jcv_priorityqueue*)mem;
+    internal->eventqueue->compare_fn = (FJCVPriorityQueueCompare)jcv_halfedge_compare;
+    internal->eventqueue->set_pos = (FJCVPriorityQueueSetPos)jcv_halfedge_set_pos;
+    internal->eventqueue->get_pos = (FJCVPriorityQueueGetPos)jcv_halfedge_get_pos;
+
     mem += sizeof(jcv_priorityqueue);
     assert( ((uintptr_t)mem & (sizeof(void*)-1)) == 0 );
 

--- a/src/jc_voronoi.h
+++ b/src/jc_voronoi.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2023 Mathias Westerdahl
+// Copyright (c) 2015-2026 Mathias Westerdahl
 // For LICENSE (MIT), USAGE or HISTORY, see bottom of file
 
 #ifndef JC_VORONOI_H
@@ -339,37 +339,19 @@ static inline jcv_real jcv_point_dist( const jcv_point* pt1, const jcv_point* pt
 
 #pragma pack(push, 1)
 
-typedef struct jcv_arc_
-{
-  struct jcv_arc_*  rb_parent;
-  struct jcv_arc_*  rb_left;
-  struct jcv_arc_*  rb_right;
-
-  jcv_site*             site;
-  jcv_edge*             edge;
-  struct jcv_event_*    circle_event;
-  uint8_t               is_leaf : 1;
-  uint8_t                       : 7;
-} jcv_arc;
-
-typedef struct jcv_event_
-{
-    jcv_arc*    arc;    // The associated parabola
-    jcv_point   p;
-    uint8_t     type    : 1; // 0: site event, 1: circle event
-    uint8_t     deleted : 1; // 1: the event has been discarded
-    uint8_t             : 6;
-} jcv_event;
-
 typedef struct jcv_halfedge_
 {
     jcv_edge*               edge;
     struct jcv_halfedge_*   left;
     struct jcv_halfedge_*   right;
+    struct jcv_halfedge_*   rb_parent;
+    struct jcv_halfedge_*   rb_left;
+    struct jcv_halfedge_*   rb_right;
     jcv_point               vertex;
     jcv_real                y;
     int                     direction; // 0=left, 1=right
     int                     pqpos;
+    uint8_t                 rb_red;
 } jcv_halfedge;
 
 typedef struct jcv_memoryblock_
@@ -381,10 +363,9 @@ typedef struct jcv_memoryblock_
 
 
 typedef int  (*FJCVPriorityQueuePrint)(const void* node, int pos);
-
 typedef int  (*FJCVPriorityQueueCompare)(const void* a, const void* b);
-typedef void (*FJCVPriorityQueueSetPos)(void* a, int pos);
-typedef int  (*FJCVPriorityQueueGetPos)(const void* a);
+typedef void (*FJCVPriorityQueueSetPos)(void* node, int pos);
+typedef int  (*FJCVPriorityQueueGetPos)(const void* node);
 
 typedef struct jcv_priorityqueue_
 {
@@ -404,7 +385,8 @@ struct jcv_context_internal_
     jcv_edge*           edges;
     jcv_halfedge*       beachline_start;
     jcv_halfedge*       beachline_end;
-    jcv_halfedge*       last_inserted;
+    jcv_halfedge*       beachline_root;
+    jcv_halfedge        beachline_nil;
     jcv_priorityqueue*  eventqueue;
 
     jcv_site*           sites;
@@ -783,8 +765,12 @@ static inline jcv_halfedge* jcv_halfedge_new(jcv_context_internal* internal, jcv
     he->edge        = e;
     he->left        = 0;
     he->right       = 0;
+    he->rb_parent   = &internal->beachline_nil;
+    he->rb_left     = &internal->beachline_nil;
+    he->rb_right    = &internal->beachline_nil;
     he->direction   = direction;
     he->pqpos       = 0;
+    he->rb_red      = 0;
     // These are set outside
     //he->y
     //he->vertex
@@ -859,6 +845,289 @@ static int jcv_halfedge_rightof(const jcv_halfedge* he, const jcv_point* p)
     return (he->direction == JCV_DIRECTION_LEFT ? above : !above);
 }
 
+// The linked beachline provides constant-time neighboring halfedges. The
+// red-black tree indexes that same order so the predecessor at a site event can
+// be found in logarithmic time.
+static void jcv_beachline_init(jcv_context_internal* internal)
+{
+    jcv_halfedge* nil = &internal->beachline_nil;
+    memset(nil, 0, sizeof(*nil));
+    nil->rb_parent = nil;
+    nil->rb_left = nil;
+    nil->rb_right = nil;
+    nil->rb_red = 0;
+    internal->beachline_root = nil;
+}
+
+static void jcv_rb_rotate_left(jcv_context_internal* internal, jcv_halfedge* node)
+{
+    jcv_halfedge* nil = &internal->beachline_nil;
+    jcv_halfedge* child = node->rb_right;
+    node->rb_right = child->rb_left;
+    if (child->rb_left != nil)
+        child->rb_left->rb_parent = node;
+    child->rb_parent = node->rb_parent;
+    if (node->rb_parent == nil)
+        internal->beachline_root = child;
+    else if (node == node->rb_parent->rb_left)
+        node->rb_parent->rb_left = child;
+    else
+        node->rb_parent->rb_right = child;
+    child->rb_left = node;
+    node->rb_parent = child;
+}
+
+static void jcv_rb_rotate_right(jcv_context_internal* internal, jcv_halfedge* node)
+{
+    jcv_halfedge* nil = &internal->beachline_nil;
+    jcv_halfedge* child = node->rb_left;
+    node->rb_left = child->rb_right;
+    if (child->rb_right != nil)
+        child->rb_right->rb_parent = node;
+    child->rb_parent = node->rb_parent;
+    if (node->rb_parent == nil)
+        internal->beachline_root = child;
+    else if (node == node->rb_parent->rb_right)
+        node->rb_parent->rb_right = child;
+    else
+        node->rb_parent->rb_left = child;
+    child->rb_right = node;
+    node->rb_parent = child;
+}
+
+static void jcv_rb_insert_fixup(jcv_context_internal* internal, jcv_halfedge* node)
+{
+    while (node->rb_parent->rb_red)
+    {
+        if (node->rb_parent == node->rb_parent->rb_parent->rb_left)
+        {
+            jcv_halfedge* uncle = node->rb_parent->rb_parent->rb_right;
+            if (uncle->rb_red)
+            {
+                node->rb_parent->rb_red = 0;
+                uncle->rb_red = 0;
+                node->rb_parent->rb_parent->rb_red = 1;
+                node = node->rb_parent->rb_parent;
+            }
+            else
+            {
+                if (node == node->rb_parent->rb_right)
+                {
+                    node = node->rb_parent;
+                    jcv_rb_rotate_left(internal, node);
+                }
+                node->rb_parent->rb_red = 0;
+                node->rb_parent->rb_parent->rb_red = 1;
+                jcv_rb_rotate_right(internal, node->rb_parent->rb_parent);
+            }
+        }
+        else
+        {
+            jcv_halfedge* uncle = node->rb_parent->rb_parent->rb_left;
+            if (uncle->rb_red)
+            {
+                node->rb_parent->rb_red = 0;
+                uncle->rb_red = 0;
+                node->rb_parent->rb_parent->rb_red = 1;
+                node = node->rb_parent->rb_parent;
+            }
+            else
+            {
+                if (node == node->rb_parent->rb_left)
+                {
+                    node = node->rb_parent;
+                    jcv_rb_rotate_right(internal, node);
+                }
+                node->rb_parent->rb_red = 0;
+                node->rb_parent->rb_parent->rb_red = 1;
+                jcv_rb_rotate_left(internal, node->rb_parent->rb_parent);
+            }
+        }
+    }
+    internal->beachline_root->rb_red = 0;
+}
+
+static jcv_halfedge* jcv_rb_minimum(jcv_context_internal* internal, jcv_halfedge* node)
+{
+    jcv_halfedge* nil = &internal->beachline_nil;
+    while (node->rb_left != nil)
+        node = node->rb_left;
+    return node;
+}
+
+static void jcv_rb_transplant(jcv_context_internal* internal, jcv_halfedge* oldnode, jcv_halfedge* newnode)
+{
+    jcv_halfedge* nil = &internal->beachline_nil;
+    if (oldnode->rb_parent == nil)
+        internal->beachline_root = newnode;
+    else if (oldnode == oldnode->rb_parent->rb_left)
+        oldnode->rb_parent->rb_left = newnode;
+    else
+        oldnode->rb_parent->rb_right = newnode;
+    newnode->rb_parent = oldnode->rb_parent;
+}
+
+static void jcv_rb_remove_fixup(jcv_context_internal* internal, jcv_halfedge* node)
+{
+    while (node != internal->beachline_root && !node->rb_red)
+    {
+        if (node == node->rb_parent->rb_left)
+        {
+            jcv_halfedge* sibling = node->rb_parent->rb_right;
+            if (sibling->rb_red)
+            {
+                sibling->rb_red = 0;
+                node->rb_parent->rb_red = 1;
+                jcv_rb_rotate_left(internal, node->rb_parent);
+                sibling = node->rb_parent->rb_right;
+            }
+            if (!sibling->rb_left->rb_red && !sibling->rb_right->rb_red)
+            {
+                sibling->rb_red = 1;
+                node = node->rb_parent;
+            }
+            else
+            {
+                if (!sibling->rb_right->rb_red)
+                {
+                    sibling->rb_left->rb_red = 0;
+                    sibling->rb_red = 1;
+                    jcv_rb_rotate_right(internal, sibling);
+                    sibling = node->rb_parent->rb_right;
+                }
+                sibling->rb_red = node->rb_parent->rb_red;
+                node->rb_parent->rb_red = 0;
+                sibling->rb_right->rb_red = 0;
+                jcv_rb_rotate_left(internal, node->rb_parent);
+                node = internal->beachline_root;
+            }
+        }
+        else
+        {
+            jcv_halfedge* sibling = node->rb_parent->rb_left;
+            if (sibling->rb_red)
+            {
+                sibling->rb_red = 0;
+                node->rb_parent->rb_red = 1;
+                jcv_rb_rotate_right(internal, node->rb_parent);
+                sibling = node->rb_parent->rb_left;
+            }
+            if (!sibling->rb_right->rb_red && !sibling->rb_left->rb_red)
+            {
+                sibling->rb_red = 1;
+                node = node->rb_parent;
+            }
+            else
+            {
+                if (!sibling->rb_left->rb_red)
+                {
+                    sibling->rb_right->rb_red = 0;
+                    sibling->rb_red = 1;
+                    jcv_rb_rotate_left(internal, sibling);
+                    sibling = node->rb_parent->rb_left;
+                }
+                sibling->rb_red = node->rb_parent->rb_red;
+                node->rb_parent->rb_red = 0;
+                sibling->rb_left->rb_red = 0;
+                jcv_rb_rotate_right(internal, node->rb_parent);
+                node = internal->beachline_root;
+            }
+        }
+    }
+    node->rb_red = 0;
+}
+
+static void jcv_rb_remove(jcv_context_internal* internal, jcv_halfedge* node)
+{
+    jcv_halfedge* nil = &internal->beachline_nil;
+    jcv_halfedge* replacement = node;
+    jcv_halfedge* child;
+    uint8_t replacement_was_red = replacement->rb_red;
+
+    if (node->rb_left == nil)
+    {
+        child = node->rb_right;
+        jcv_rb_transplant(internal, node, node->rb_right);
+    }
+    else if (node->rb_right == nil)
+    {
+        child = node->rb_left;
+        jcv_rb_transplant(internal, node, node->rb_left);
+    }
+    else
+    {
+        replacement = jcv_rb_minimum(internal, node->rb_right);
+        replacement_was_red = replacement->rb_red;
+        child = replacement->rb_right;
+        if (replacement->rb_parent == node)
+        {
+            child->rb_parent = replacement;
+        }
+        else
+        {
+            jcv_rb_transplant(internal, replacement, replacement->rb_right);
+            replacement->rb_right = node->rb_right;
+            replacement->rb_right->rb_parent = replacement;
+        }
+        jcv_rb_transplant(internal, node, replacement);
+        replacement->rb_left = node->rb_left;
+        replacement->rb_left->rb_parent = replacement;
+        replacement->rb_red = node->rb_red;
+    }
+
+    if (!replacement_was_red)
+        jcv_rb_remove_fixup(internal, child);
+
+    node->rb_parent = nil;
+    node->rb_left = nil;
+    node->rb_right = nil;
+    node->rb_red = 0;
+    nil->rb_parent = nil;
+    nil->rb_red = 0;
+}
+
+static void jcv_beachline_insert_after(jcv_context_internal* internal, jcv_halfedge* after, jcv_halfedge* node)
+{
+    jcv_halfedge* nil = &internal->beachline_nil;
+    jcv_halfedge* parent = nil;
+
+    node->rb_left = nil;
+    node->rb_right = nil;
+    node->rb_red = 1;
+
+    if (internal->beachline_root == nil)
+    {
+        internal->beachline_root = node;
+    }
+    else if (after == internal->beachline_start)
+    {
+        parent = jcv_rb_minimum(internal, internal->beachline_root);
+        assert(parent->rb_left == nil);
+        parent->rb_left = node;
+    }
+    else if (after->rb_right == nil)
+    {
+        parent = after;
+        parent->rb_right = node;
+    }
+    else
+    {
+        parent = jcv_rb_minimum(internal, after->rb_right);
+        assert(parent->rb_left == nil);
+        parent->rb_left = node;
+    }
+
+    node->rb_parent = parent;
+    jcv_halfedge_link(after, node);
+    jcv_rb_insert_fixup(internal, node);
+}
+
+static void jcv_beachline_remove(jcv_context_internal* internal, jcv_halfedge* node)
+{
+    jcv_rb_remove(internal, node);
+    jcv_halfedge_unlink(node);
+}
+
 // Keeps the priority queue sorted with events sorted in ascending order
 // Return 1 if the edges needs to be swapped
 static inline int jcv_halfedge_compare( const jcv_halfedge* he1, const jcv_halfedge* he2 )
@@ -866,14 +1135,19 @@ static inline int jcv_halfedge_compare( const jcv_halfedge* he1, const jcv_halfe
 	return  (he1->y == he2->y) ? he1->vertex.x > he2->vertex.x : he1->y > he2->y;
 }
 
-static inline void jcv_halfedge_set_pos(jcv_halfedge* he, int pos )
+static int jcv_halfedge_compare_void(const void* a, const void* b)
 {
-	he->pqpos = pos;
+    return jcv_halfedge_compare((const jcv_halfedge*)a, (const jcv_halfedge*)b);
 }
 
-static inline int jcv_halfedge_get_pos( const jcv_halfedge* he )
+static void jcv_halfedge_set_pos_void(void* node, int pos)
 {
-	return he->pqpos;
+    ((jcv_halfedge*)node)->pqpos = pos;
+}
+
+static int jcv_halfedge_get_pos_void(const void* node)
+{
+    return ((const jcv_halfedge*)node)->pqpos;
 }
 
 static int jcv_halfedge_intersect(const jcv_halfedge* he1, const jcv_halfedge* he2, jcv_point* out)
@@ -916,13 +1190,11 @@ static int jcv_halfedge_intersect(const jcv_halfedge* he1, const jcv_halfedge* h
 
 static int jcv_pq_moveup(jcv_priorityqueue* pq, int pos)
 {
-    // jcv_halfedge** items = (jcv_halfedge**)pq->items;
-    // jcv_halfedge* node = items[pos];
     void** items = pq->items;
     void* node = items[pos];
 
     for( int parent = (pos >> 1);
-         pos > 1 && pq->compare(items[parent], node);
+         pos > 1 && pq->compare_fn(items[parent], node);
          pos = parent, parent = parent >> 1)
     {
         items[pos] = items[parent];
@@ -940,7 +1212,7 @@ static int jcv_pq_maxchild(jcv_priorityqueue* pq, int pos)
     if( child >= pq->numitems )
         return 0;
     void** items = pq->items;
-    if( (child + 1) < pq->numitems && pq->compare(items[child], items[child+1]) )
+    if( (child + 1) < pq->numitems && pq->compare_fn(items[child], items[child+1]) )
         return child+1;
     return child;
 }
@@ -951,7 +1223,7 @@ static int jcv_pq_movedown(jcv_priorityqueue* pq, int pos)
     void* node = items[pos];
 
     int child = jcv_pq_maxchild(pq, pos);
-    while( child && pq->compare(node, items[child]) )
+    while( child && pq->compare_fn(node, items[child]) )
     {
         items[pos] = items[child];
         pq->set_pos(items[pos], pos);
@@ -965,17 +1237,16 @@ static int jcv_pq_movedown(jcv_priorityqueue* pq, int pos)
 }
 
 static void jcv_pq_create(jcv_priorityqueue* pq, int capacity, void** buffer,
-                            FJCVPriorityQueueCompare compare_fn,
-                            FJCVPriorityQueueSetPos set_pos_fn,
-                            FJCVPriorityQueueGetPos get_pos_fn)
+                          FJCVPriorityQueueCompare compare,
+                          FJCVPriorityQueueSetPos set_pos,
+                          FJCVPriorityQueueGetPos get_pos)
 {
     pq->maxnumitems = capacity;
     pq->numitems    = 1;
     pq->items       = buffer;
-
-    pq->compare = compare_fn;
-    pq->set_pos = set_pos_fn;
-    pq->get_pos = get_pos_fn;
+    pq->compare_fn  = compare;
+    pq->set_pos     = set_pos;
+    pq->get_pos     = get_pos;
 }
 
 static int jcv_pq_empty(jcv_priorityqueue* pq)
@@ -994,8 +1265,13 @@ static int jcv_pq_push(jcv_priorityqueue* pq, void* node)
 static void* jcv_pq_pop(jcv_priorityqueue* pq)
 {
     void* node = pq->items[1];
-    pq->items[1] = pq->items[--pq->numitems];
-    jcv_pq_movedown(pq, 1);
+    --pq->numitems;
+    pq->set_pos(node, 0);
+    if (pq->numitems > 1)
+    {
+        pq->items[1] = pq->items[pq->numitems];
+        jcv_pq_movedown(pq, 1);
+    }
     return node;
 }
 
@@ -1012,14 +1288,17 @@ static void jcv_pq_remove(jcv_priorityqueue* pq, void* node)
     if( pos == 0 )
         return;
 
-    jcv_halfedge** items = (jcv_halfedge**)pq->items;
+    void** items = pq->items;
+    int last = --pq->numitems;
+    pq->set_pos(node, 0);
+    if (pos == last)
+        return;
 
-    items[pos] = items[--pq->numitems];
-    if( pq->compare( node, items[pos] ) )
-        jcv_pq_moveup( pq, pos );
+    items[pos] = items[last];
+    if( pos > 1 && pq->compare_fn(items[pos >> 1], items[pos]) )
+        jcv_pq_moveup(pq, pos);
     else
-        jcv_pq_movedown( pq, pos );
-    pq->set_pos(node, pos);
+        jcv_pq_movedown(pq, pos);
 }
 
 // internal functions
@@ -1032,36 +1311,22 @@ static inline jcv_site* jcv_nextsite(jcv_context_internal* internal)
 static jcv_halfedge* jcv_get_edge_above_x(jcv_context_internal* internal, const jcv_point* p)
 {
     // Gets the arc on the beach line at the x coordinate (i.e. right above the new site event)
-
-    // A good guess it's close by (Can be optimized)
-    jcv_halfedge* he = internal->last_inserted;
-    if( !he )
+    jcv_halfedge* nil = &internal->beachline_nil;
+    jcv_halfedge* node = internal->beachline_root;
+    jcv_halfedge* predecessor = internal->beachline_start;
+    while (node != nil)
     {
-        if( p->x < (internal->rect.max.x - internal->rect.min.x) / 2 )
-            he = internal->beachline_start;
+        if (jcv_halfedge_rightof(node, p))
+        {
+            predecessor = node;
+            node = node->rb_right;
+        }
         else
-            he = internal->beachline_end;
-    }
-
-    //
-    if( he == internal->beachline_start || (he != internal->beachline_end && jcv_halfedge_rightof(he, p)) )
-    {
-        do {
-            he = he->right;
+        {
+            node = node->rb_left;
         }
-        while( he != internal->beachline_end && jcv_halfedge_rightof(he, p) );
-
-        he = he->left;
     }
-    else
-    {
-        do {
-            he = he->left;
-        }
-        while( he != internal->beachline_start && !jcv_halfedge_rightof(he, p) );
-    }
-
-    return he;
+    return predecessor;
 }
 
 static int jcv_check_circle_event(const jcv_halfedge* he1, const jcv_halfedge* he2, jcv_point* vertex)
@@ -1091,10 +1356,8 @@ static void jcv_site_event(jcv_context_internal* internal, jcv_site* site)
     jcv_halfedge* edge1 = jcv_halfedge_new(internal, edge, JCV_DIRECTION_LEFT);
     jcv_halfedge* edge2 = jcv_halfedge_new(internal, edge, JCV_DIRECTION_RIGHT);
 
-    jcv_halfedge_link(left, edge1);
-    jcv_halfedge_link(edge1, edge2);
-
-    internal->last_inserted = right;
+    jcv_beachline_insert_after(internal, left, edge1);
+    jcv_beachline_insert_after(internal, edge1, edge2);
 
     jcv_point p;
     if( jcv_check_circle_event( left, edge1, &p ) )
@@ -1378,11 +1641,9 @@ static void jcv_circle_event(jcv_context_internal* internal)
     jcv_endpos(internal, left->edge, &vertex, left->direction);
     jcv_endpos(internal, right->edge, &vertex, right->direction);
 
-    internal->last_inserted = rightright;
-
     jcv_pq_remove(internal->eventqueue, right);
-    jcv_halfedge_unlink(left);
-    jcv_halfedge_unlink(right);
+    jcv_beachline_remove(internal, left);
+    jcv_beachline_remove(internal, right);
     jcv_halfedge_delete(internal, left);
     jcv_halfedge_delete(internal, right);
 
@@ -1400,7 +1661,7 @@ static void jcv_circle_event(jcv_context_internal* internal)
     internal->edges = edge;
 
     jcv_halfedge* he = jcv_halfedge_new(internal, edge, direction);
-    jcv_halfedge_link(leftleft, he);
+    jcv_beachline_insert_after(internal, leftleft, he);
     jcv_endpos(internal, edge, &vertex, JCV_DIRECTION_RIGHT - direction);
 
     jcv_point p;
@@ -1545,10 +1806,6 @@ static jcv_context_internal* jcv_alloc_internal(int num_points, void* userallocc
 
     mem = (char*)jcv_align(mem, sizeof(void*));
     internal->eventqueue = (jcv_priorityqueue*)mem;
-    internal->eventqueue->compare_fn = (FJCVPriorityQueueCompare)jcv_halfedge_compare;
-    internal->eventqueue->set_pos = (FJCVPriorityQueueSetPos)jcv_halfedge_set_pos;
-    internal->eventqueue->get_pos = (FJCVPriorityQueueGetPos)jcv_halfedge_get_pos;
-
     mem += sizeof(jcv_priorityqueue);
     assert( ((uintptr_t)mem & (sizeof(void*)-1)) == 0 );
 
@@ -1568,6 +1825,7 @@ void jcv_diagram_generate_useralloc(int num_points, const jcv_point* points, con
 
     jcv_context_internal* internal = jcv_alloc_internal(num_points, userallocctx, allocfn, freefn);
 
+    jcv_beachline_init(internal);
     internal->beachline_start = jcv_halfedge_new(internal, 0, 0);
     internal->beachline_end = jcv_halfedge_new(internal, 0, 0);
 
@@ -1576,15 +1834,9 @@ void jcv_diagram_generate_useralloc(int num_points, const jcv_point* points, con
     internal->beachline_end->left       = internal->beachline_start;
     internal->beachline_end->right      = 0;
 
-    internal->last_inserted = 0;
-
     int max_num_events = num_points*2; // beachline can have max 2*n-5 parabolas
-    jcv_priorityqueue* pq = internal->eventqueue;
-    jcv_pq_create(pq, max_num_events, (void**)internal->eventmem,
-                    (FJCVPriorityQueueCompare)jcv_event_compare,
-                    (FJCVPriorityQueueSetPos)jcv_event_set_pos,
-                    (FJCVPriorityQueueGetPos)jcv_event_get_pos);
-
+    jcv_pq_create(internal->eventqueue, max_num_events, (void**)internal->eventmem,
+                  jcv_halfedge_compare_void, jcv_halfedge_set_pos_void, jcv_halfedge_get_pos_void);
 
     internal->numsites = num_points;
     jcv_site* sites = internal->sites;
@@ -1688,6 +1940,7 @@ ABOUT:
     A fast single file 2D voronoi diagram generator
 
 HISTORY:
+    0.10    2026-07-19  - Use a BST to manipulate the beachline
     0.9     2023-01-22  - Modified the Delauney iterator creation api
     0.8     2022-12-20  - Added fix for missing border edges
                           More robust removal of duplicate graph edges

--- a/src/main.c
+++ b/src/main.c
@@ -168,11 +168,16 @@ static int debug_skip_point(const jcv_point* pt)
     return 0;
 }
 
+static inline int is_ascii_char(char c)
+{
+    return (unsigned char)c <= 0x7f;
+}
+
 static inline int is_ascii(const char* chars, size_t len)
 {
     for( size_t i = 0; i < len; ++i )
     {
-        if (!isascii((int)chars[i]))
+        if (!is_ascii_char(chars[i]))
             return 0;
     }
     return 1;

--- a/src/main.c
+++ b/src/main.c
@@ -144,7 +144,7 @@ static void relax_points(const jcv_diagram* diagram, jcv_point* points)
     }
 }
 
-static void Usage()
+static void Usage(void)
 {
     printf("Usage: main [options]\n");
     printf("\t-n <num points>\n");
@@ -195,14 +195,15 @@ static int read_input_csv(FILE* file, jcv_point** points, uint32_t* length, jcv_
     uint32_t len = 0;
     char buffer[64];
 
-    while( !feof(file) )
+    while( fgets(buffer, sizeof(buffer), file) )
     {
-        fgets(buffer, sizeof(buffer), file);
-
         jcv_point pt1;
         jcv_point pt2;
+#if defined(JCV_USE_DOUBLE)
+        int numscanned = sscanf(buffer, "%lf %lf %lf %lf\n", &pt1.x, &pt1.y, &pt2.x, &pt2.y);
+#else
         int numscanned = sscanf(buffer, "%f %f %f %f\n", &pt1.x, &pt1.y, &pt2.x, &pt2.y);
-
+#endif
         if( numscanned == 4 )
         {
             if (rect)

--- a/src/main.c
+++ b/src/main.c
@@ -601,7 +601,7 @@ int main(int argc, const char** argv)
     }
 
     char path[512];
-    sprintf(path, "%s", outputfile);
+    snprintf(path, sizeof(path), "%s", outputfile);
     printf("Writing %s\n", path);
 
     wrap_stbi_write_png(path, width, height, 3, image, stride);

--- a/src/stb_image_write.h
+++ b/src/stb_image_write.h
@@ -1,5 +1,5 @@
-/* stb_image_write - v1.02 - public domain - http://nothings.org/stb/stb_image_write.h
-   writes out PNG/BMP/TGA images to C stdio - Sean Barrett 2010-2015
+/* stb_image_write - v1.16 - public domain - http://nothings.org/stb
+   writes out PNG/BMP/TGA/JPEG/HDR images to C stdio - Sean Barrett 2010-2015
                                      no warranty implied; use at your own risk
 
    Before #including,
@@ -12,40 +12,63 @@
 
 ABOUT:
 
-   This header file is a library for writing images to C stdio. It could be
-   adapted to write to memory or a general streaming interface; let me know.
+   This header file is a library for writing images to C stdio or a callback.
 
    The PNG output is not optimal; it is 20-50% larger than the file
-   written by a decent optimizing implementation. This library is designed
-   for source code compactness and simplicity, not optimal image file size
-   or run-time performance.
+   written by a decent optimizing implementation; though providing a custom
+   zlib compress function (see STBIW_ZLIB_COMPRESS) can mitigate that.
+   This library is designed for source code compactness and simplicity,
+   not optimal image file size or run-time performance.
 
 BUILDING:
 
    You can #define STBIW_ASSERT(x) before the #include to avoid using assert.h.
    You can #define STBIW_MALLOC(), STBIW_REALLOC(), and STBIW_FREE() to replace
    malloc,realloc,free.
-   You can define STBIW_MEMMOVE() to replace memmove()
+   You can #define STBIW_MEMMOVE() to replace memmove()
+   You can #define STBIW_ZLIB_COMPRESS to use a custom zlib-style compress function
+   for PNG compression (instead of the builtin one), it must have the following signature:
+   unsigned char * my_compress(unsigned char *data, int data_len, int *out_len, int quality);
+   The returned data will be freed with STBIW_FREE() (free() by default),
+   so it must be heap allocated with STBIW_MALLOC() (malloc() by default),
+
+UNICODE:
+
+   If compiling for Windows and you wish to use Unicode filenames, compile
+   with
+       #define STBIW_WINDOWS_UTF8
+   and pass utf8-encoded filenames. Call stbiw_convert_wchar_to_utf8 to convert
+   Windows wchar_t filenames to utf8.
 
 USAGE:
 
-   There are four functions, one for each image file format:
+   There are five functions, one for each image file format:
 
      int stbi_write_png(char const *filename, int w, int h, int comp, const void *data, int stride_in_bytes);
      int stbi_write_bmp(char const *filename, int w, int h, int comp, const void *data);
      int stbi_write_tga(char const *filename, int w, int h, int comp, const void *data);
+     int stbi_write_jpg(char const *filename, int w, int h, int comp, const void *data, int quality);
      int stbi_write_hdr(char const *filename, int w, int h, int comp, const float *data);
 
-   There are also four equivalent functions that use an arbitrary write function. You are
+     void stbi_flip_vertically_on_write(int flag); // flag is non-zero to flip data vertically
+
+   There are also five equivalent functions that use an arbitrary write function. You are
    expected to open/close your file-equivalent before and after calling these:
 
      int stbi_write_png_to_func(stbi_write_func *func, void *context, int w, int h, int comp, const void  *data, int stride_in_bytes);
      int stbi_write_bmp_to_func(stbi_write_func *func, void *context, int w, int h, int comp, const void  *data);
      int stbi_write_tga_to_func(stbi_write_func *func, void *context, int w, int h, int comp, const void  *data);
      int stbi_write_hdr_to_func(stbi_write_func *func, void *context, int w, int h, int comp, const float *data);
+     int stbi_write_jpg_to_func(stbi_write_func *func, void *context, int x, int y, int comp, const void *data, int quality);
 
    where the callback is:
       void stbi_write_func(void *context, void *data, int size);
+
+   You can configure it with these global variables:
+      int stbi_write_tga_with_rle;             // defaults to true; set to 0 to disable RLE
+      int stbi_write_png_compression_level;    // defaults to 8; set to higher for more compression
+      int stbi_write_force_png_filter;         // defaults to -1; set to 0..5 to force a filter mode
+
 
    You can define STBI_WRITE_NO_STDIO to disable the file variant of these
    functions, so the library will not use stdio.h at all. However, this will
@@ -73,6 +96,9 @@ USAGE:
    writer, both because it is in BGR order and because it may have padding
    at the end of the line.)
 
+   PNG allows you to set the deflate compression level by setting the global
+   variable 'stbi_write_png_compression_level' (it defaults to 8).
+
    HDR expects linear float data. Since the format is always 32-bit rgb(e)
    data, alpha (if provided) is discarded, and for monochrome data it is
    replicated across all three channels.
@@ -80,20 +106,23 @@ USAGE:
    TGA supports RLE or non-RLE compressed data. To use non-RLE-compressed
    data, set the global variable 'stbi_write_tga_with_rle' to 0.
 
+   JPEG does ignore alpha channels in input data; quality is between 1 and 100.
+   Higher quality looks better but results in a bigger image.
+   JPEG baseline (no JPEG progressive).
+
 CREDITS:
 
-   PNG/BMP/TGA
-      Sean Barrett
-   HDR
-      Baldur Karlsson
-   TGA monochrome:
-      Jean-Sebastien Guay
-   misc enhancements:
-      Tim Kelsey
-   TGA RLE
-      Alan Hickman
-   initial file IO callback implementation
-      Emmanuel Julien
+
+   Sean Barrett           -    PNG/BMP/TGA
+   Baldur Karlsson        -    HDR
+   Jean-Sebastien Guay    -    TGA monochrome
+   Tim Kelsey             -    misc enhancements
+   Alan Hickman           -    TGA RLE
+   Emmanuel Julien        -    initial file IO callback implementation
+   Jon Olick              -    original jo_jpeg.cpp code
+   Daniel Gibson          -    integrate JPEG, allow external zlib
+   Aarni Koskela          -    allow choosing PNG filter
+
    bugfixes:
       github:Chribba
       Guillaume Chereau
@@ -103,27 +132,44 @@ CREDITS:
       Jonas Karlsson
       Filip Wasil
       Thatcher Ulrich
-      
+      github:poppolopoppo
+      Patrick Boettcher
+      github:xeekworx
+      Cap Petschulat
+      Simon Rodriguez
+      Ivan Tikhonov
+      github:ignotion
+      Adam Schackart
+      Andrew Kensler
+
 LICENSE
 
-This software is dual-licensed to the public domain and under the following
-license: you are granted a perpetual, irrevocable license to copy, modify,
-publish, and distribute this file as you see fit.
+  See end of file for license information.
 
 */
 
 #ifndef INCLUDE_STB_IMAGE_WRITE_H
 #define INCLUDE_STB_IMAGE_WRITE_H
 
+#include <stdlib.h>
+
+// if STB_IMAGE_WRITE_STATIC causes problems, try defining STBIWDEF to 'inline' or 'static inline'
+#ifndef STBIWDEF
+#ifdef STB_IMAGE_WRITE_STATIC
+#define STBIWDEF  static
+#else
 #ifdef __cplusplus
-extern "C" {
+#define STBIWDEF  extern "C"
+#else
+#define STBIWDEF  extern
+#endif
+#endif
 #endif
 
-#ifdef STB_IMAGE_WRITE_STATIC
-#define STBIWDEF static
-#else
-#define STBIWDEF extern
-extern int stbi_write_tga_with_rle;
+#ifndef STB_IMAGE_WRITE_STATIC  // C++ forbids static forward declarations
+STBIWDEF int stbi_write_tga_with_rle;
+STBIWDEF int stbi_write_png_compression_level;
+STBIWDEF int stbi_write_force_png_filter;
 #endif
 
 #ifndef STBI_WRITE_NO_STDIO
@@ -131,6 +177,11 @@ STBIWDEF int stbi_write_png(char const *filename, int w, int h, int comp, const 
 STBIWDEF int stbi_write_bmp(char const *filename, int w, int h, int comp, const void  *data);
 STBIWDEF int stbi_write_tga(char const *filename, int w, int h, int comp, const void  *data);
 STBIWDEF int stbi_write_hdr(char const *filename, int w, int h, int comp, const float *data);
+STBIWDEF int stbi_write_jpg(char const *filename, int x, int y, int comp, const void  *data, int quality);
+
+#ifdef STBIW_WINDOWS_UTF8
+STBIWDEF int stbiw_convert_wchar_to_utf8(char *buffer, size_t bufferlen, const wchar_t* input);
+#endif
 #endif
 
 typedef void stbi_write_func(void *context, void *data, int size);
@@ -139,10 +190,9 @@ STBIWDEF int stbi_write_png_to_func(stbi_write_func *func, void *context, int w,
 STBIWDEF int stbi_write_bmp_to_func(stbi_write_func *func, void *context, int w, int h, int comp, const void  *data);
 STBIWDEF int stbi_write_tga_to_func(stbi_write_func *func, void *context, int w, int h, int comp, const void  *data);
 STBIWDEF int stbi_write_hdr_to_func(stbi_write_func *func, void *context, int w, int h, int comp, const float *data);
+STBIWDEF int stbi_write_jpg_to_func(stbi_write_func *func, void *context, int x, int y, int comp, const void  *data, int quality);
 
-#ifdef __cplusplus
-}
-#endif
+STBIWDEF void stbi_flip_vertically_on_write(int flip_boolean);
 
 #endif//INCLUDE_STB_IMAGE_WRITE_H
 
@@ -197,10 +247,29 @@ STBIWDEF int stbi_write_hdr_to_func(stbi_write_func *func, void *context, int w,
 
 #define STBIW_UCHAR(x) (unsigned char) ((x) & 0xff)
 
+#ifdef STB_IMAGE_WRITE_STATIC
+static int stbi_write_png_compression_level = 8;
+static int stbi_write_tga_with_rle = 1;
+static int stbi_write_force_png_filter = -1;
+#else
+int stbi_write_png_compression_level = 8;
+int stbi_write_tga_with_rle = 1;
+int stbi_write_force_png_filter = -1;
+#endif
+
+static int stbi__flip_vertically_on_write = 0;
+
+STBIWDEF void stbi_flip_vertically_on_write(int flag)
+{
+   stbi__flip_vertically_on_write = flag;
+}
+
 typedef struct
 {
    stbi_write_func *func;
    void *context;
+   unsigned char buffer[64];
+   int buf_used;
 } stbi__write_context;
 
 // initialize a callback-based context
@@ -217,9 +286,52 @@ static void stbi__stdio_write(void *context, void *data, int size)
    fwrite(data,1,size,(FILE*) context);
 }
 
+#if defined(_WIN32) && defined(STBIW_WINDOWS_UTF8)
+#ifdef __cplusplus
+#define STBIW_EXTERN extern "C"
+#else
+#define STBIW_EXTERN extern
+#endif
+STBIW_EXTERN __declspec(dllimport) int __stdcall MultiByteToWideChar(unsigned int cp, unsigned long flags, const char *str, int cbmb, wchar_t *widestr, int cchwide);
+STBIW_EXTERN __declspec(dllimport) int __stdcall WideCharToMultiByte(unsigned int cp, unsigned long flags, const wchar_t *widestr, int cchwide, char *str, int cbmb, const char *defchar, int *used_default);
+
+STBIWDEF int stbiw_convert_wchar_to_utf8(char *buffer, size_t bufferlen, const wchar_t* input)
+{
+   return WideCharToMultiByte(65001 /* UTF8 */, 0, input, -1, buffer, (int) bufferlen, NULL, NULL);
+}
+#endif
+
+static FILE *stbiw__fopen(char const *filename, char const *mode)
+{
+   FILE *f;
+#if defined(_WIN32) && defined(STBIW_WINDOWS_UTF8)
+   wchar_t wMode[64];
+   wchar_t wFilename[1024];
+   if (0 == MultiByteToWideChar(65001 /* UTF8 */, 0, filename, -1, wFilename, sizeof(wFilename)/sizeof(*wFilename)))
+      return 0;
+
+   if (0 == MultiByteToWideChar(65001 /* UTF8 */, 0, mode, -1, wMode, sizeof(wMode)/sizeof(*wMode)))
+      return 0;
+
+#if defined(_MSC_VER) && _MSC_VER >= 1400
+   if (0 != _wfopen_s(&f, wFilename, wMode))
+      f = 0;
+#else
+   f = _wfopen(wFilename, wMode);
+#endif
+
+#elif defined(_MSC_VER) && _MSC_VER >= 1400
+   if (0 != fopen_s(&f, filename, mode))
+      f=0;
+#else
+   f = fopen(filename, mode);
+#endif
+   return f;
+}
+
 static int stbi__start_write_file(stbi__write_context *s, const char *filename)
 {
-   FILE *f = fopen(filename, "wb");
+   FILE *f = stbiw__fopen(filename, "wb");
    stbi__start_write_callbacks(s, stbi__stdio_write, (void *) f);
    return f != NULL;
 }
@@ -233,12 +345,6 @@ static void stbi__end_write_file(stbi__write_context *s)
 
 typedef unsigned int stbiw_uint32;
 typedef int stb_image_write_test[sizeof(stbiw_uint32)==4 ? 1 : -1];
-
-#ifdef STB_IMAGE_WRITE_STATIC
-static int stbi_write_tga_with_rle = 1;
-#else
-int stbi_write_tga_with_rle = 1;
-#endif
 
 static void stbiw__writefv(stbi__write_context *s, const char *fmt, va_list v)
 {
@@ -277,11 +383,36 @@ static void stbiw__writef(stbi__write_context *s, const char *fmt, ...)
    va_end(v);
 }
 
+static void stbiw__write_flush(stbi__write_context *s)
+{
+   if (s->buf_used) {
+      s->func(s->context, &s->buffer, s->buf_used);
+      s->buf_used = 0;
+   }
+}
+
+static void stbiw__putc(stbi__write_context *s, unsigned char c)
+{
+   s->func(s->context, &c, 1);
+}
+
+static void stbiw__write1(stbi__write_context *s, unsigned char a)
+{
+   if ((size_t)s->buf_used + 1 > sizeof(s->buffer))
+      stbiw__write_flush(s);
+   s->buffer[s->buf_used++] = a;
+}
+
 static void stbiw__write3(stbi__write_context *s, unsigned char a, unsigned char b, unsigned char c)
 {
-   unsigned char arr[3];
-   arr[0] = a, arr[1] = b, arr[2] = c;
-   s->func(s->context, arr, 3);
+   int n;
+   if ((size_t)s->buf_used + 3 > sizeof(s->buffer))
+      stbiw__write_flush(s);
+   n = s->buf_used;
+   s->buf_used = n+3;
+   s->buffer[n+0] = a;
+   s->buffer[n+1] = b;
+   s->buffer[n+2] = c;
 }
 
 static void stbiw__write_pixel(stbi__write_context *s, int rgb_dir, int comp, int write_alpha, int expand_mono, unsigned char *d)
@@ -290,17 +421,15 @@ static void stbiw__write_pixel(stbi__write_context *s, int rgb_dir, int comp, in
    int k;
 
    if (write_alpha < 0)
-      s->func(s->context, &d[comp - 1], 1);
+      stbiw__write1(s, d[comp - 1]);
 
    switch (comp) {
+      case 2: // 2 pixels = mono + alpha, alpha is written separately, so same as 1-channel case
       case 1:
-         s->func(s->context,d,1);
-         break;
-      case 2:
          if (expand_mono)
             stbiw__write3(s, d[0], d[0], d[0]); // monochrome bmp
          else
-            s->func(s->context, d, 1);  // monochrome TGA
+            stbiw__write1(s, d[0]);  // monochrome TGA
          break;
       case 4:
          if (!write_alpha) {
@@ -316,7 +445,7 @@ static void stbiw__write_pixel(stbi__write_context *s, int rgb_dir, int comp, in
          break;
    }
    if (write_alpha > 0)
-      s->func(s->context, &d[comp - 1], 1);
+      stbiw__write1(s, d[comp - 1]);
 }
 
 static void stbiw__write_pixels(stbi__write_context *s, int rgb_dir, int vdir, int x, int y, int comp, void *data, int write_alpha, int scanline_pad, int expand_mono)
@@ -327,16 +456,21 @@ static void stbiw__write_pixels(stbi__write_context *s, int rgb_dir, int vdir, i
    if (y <= 0)
       return;
 
-   if (vdir < 0)
-      j_end = -1, j = y-1;
-   else
-      j_end =  y, j = 0;
+   if (stbi__flip_vertically_on_write)
+      vdir *= -1;
+
+   if (vdir < 0) {
+      j_end = -1; j = y-1;
+   } else {
+      j_end =  y; j = 0;
+   }
 
    for (; j != j_end; j += vdir) {
       for (i=0; i < x; ++i) {
          unsigned char *d = (unsigned char *) data + (j*x+i)*comp;
          stbiw__write_pixel(s, rgb_dir, comp, write_alpha, expand_mono, d);
       }
+      stbiw__write_flush(s);
       s->func(s->context, &zero, scanline_pad);
    }
 }
@@ -357,16 +491,27 @@ static int stbiw__outfile(stbi__write_context *s, int rgb_dir, int vdir, int x, 
 
 static int stbi_write_bmp_core(stbi__write_context *s, int x, int y, int comp, const void *data)
 {
-   int pad = (-x*3) & 3;
-   return stbiw__outfile(s,-1,-1,x,y,comp,1,(void *) data,0,pad,
-           "11 4 22 4" "4 44 22 444444",
-           'B', 'M', 14+40+(x*3+pad)*y, 0,0, 14+40,  // file header
-            40, x,y, 1,24, 0,0,0,0,0,0);             // bitmap header
+   if (comp != 4) {
+      // write RGB bitmap
+      int pad = (-x*3) & 3;
+      return stbiw__outfile(s,-1,-1,x,y,comp,1,(void *) data,0,pad,
+              "11 4 22 4" "4 44 22 444444",
+              'B', 'M', 14+40+(x*3+pad)*y, 0,0, 14+40,  // file header
+               40, x,y, 1,24, 0,0,0,0,0,0);             // bitmap header
+   } else {
+      // RGBA bitmaps need a v4 header
+      // use BI_BITFIELDS mode with 32bpp and alpha mask
+      // (straight BI_RGB with alpha mask doesn't work in most readers)
+      return stbiw__outfile(s,-1,-1,x,y,comp,1,(void *)data,1,0,
+         "11 4 22 4" "4 44 22 444444 4444 4 444 444 444 444",
+         'B', 'M', 14+108+x*y*4, 0, 0, 14+108, // file header
+         108, x,y, 1,32, 3,0,0,0,0,0, 0xff0000,0xff00,0xff,0xff000000u, 0, 0,0,0, 0,0,0, 0,0,0, 0,0,0); // bitmap V4 header
+   }
 }
 
 STBIWDEF int stbi_write_bmp_to_func(stbi_write_func *func, void *context, int x, int y, int comp, const void *data)
 {
-   stbi__write_context s;
+   stbi__write_context s = { 0 };
    stbi__start_write_callbacks(&s, func, context);
    return stbi_write_bmp_core(&s, x, y, comp, data);
 }
@@ -374,7 +519,7 @@ STBIWDEF int stbi_write_bmp_to_func(stbi_write_func *func, void *context, int x,
 #ifndef STBI_WRITE_NO_STDIO
 STBIWDEF int stbi_write_bmp(char const *filename, int x, int y, int comp, const void *data)
 {
-   stbi__write_context s;
+   stbi__write_context s = { 0 };
    if (stbi__start_write_file(&s,filename)) {
       int r = stbi_write_bmp_core(&s, x, y, comp, data);
       stbi__end_write_file(&s);
@@ -398,11 +543,21 @@ static int stbi_write_tga_core(stbi__write_context *s, int x, int y, int comp, v
          "111 221 2222 11", 0, 0, format, 0, 0, 0, 0, 0, x, y, (colorbytes + has_alpha) * 8, has_alpha * 8);
    } else {
       int i,j,k;
+      int jend, jdir;
 
       stbiw__writef(s, "111 221 2222 11", 0,0,format+8, 0,0,0, 0,0,x,y, (colorbytes + has_alpha) * 8, has_alpha * 8);
 
-      for (j = y - 1; j >= 0; --j) {
-          unsigned char *row = (unsigned char *) data + j * x * comp;
+      if (stbi__flip_vertically_on_write) {
+         j = 0;
+         jend = y;
+         jdir = 1;
+      } else {
+         j = y-1;
+         jend = -1;
+         jdir = -1;
+      }
+      for (; j != jend; j += jdir) {
+         unsigned char *row = (unsigned char *) data + j * x * comp;
          int len;
 
          for (i = 0; i < x; i += len) {
@@ -437,32 +592,33 @@ static int stbi_write_tga_core(stbi__write_context *s, int x, int y, int comp, v
 
             if (diff) {
                unsigned char header = STBIW_UCHAR(len - 1);
-               s->func(s->context, &header, 1);
+               stbiw__write1(s, header);
                for (k = 0; k < len; ++k) {
                   stbiw__write_pixel(s, -1, comp, has_alpha, 0, begin + k * comp);
                }
             } else {
                unsigned char header = STBIW_UCHAR(len - 129);
-               s->func(s->context, &header, 1);
+               stbiw__write1(s, header);
                stbiw__write_pixel(s, -1, comp, has_alpha, 0, begin);
             }
          }
       }
+      stbiw__write_flush(s);
    }
    return 1;
 }
 
-int stbi_write_tga_to_func(stbi_write_func *func, void *context, int x, int y, int comp, const void *data)
+STBIWDEF int stbi_write_tga_to_func(stbi_write_func *func, void *context, int x, int y, int comp, const void *data)
 {
-   stbi__write_context s;
+   stbi__write_context s = { 0 };
    stbi__start_write_callbacks(&s, func, context);
    return stbi_write_tga_core(&s, x, y, comp, (void *) data);
 }
 
 #ifndef STBI_WRITE_NO_STDIO
-int stbi_write_tga(char const *filename, int x, int y, int comp, const void *data)
+STBIWDEF int stbi_write_tga(char const *filename, int x, int y, int comp, const void *data)
 {
-   stbi__write_context s;
+   stbi__write_context s = { 0 };
    if (stbi__start_write_file(&s,filename)) {
       int r = stbi_write_tga_core(&s, x, y, comp, (void *) data);
       stbi__end_write_file(&s);
@@ -475,11 +631,12 @@ int stbi_write_tga(char const *filename, int x, int y, int comp, const void *dat
 // *************************************************************************************************
 // Radiance RGBE HDR writer
 // by Baldur Karlsson
-#ifndef STBI_WRITE_NO_STDIO
 
 #define stbiw__max(a, b)  ((a) > (b) ? (a) : (b))
 
-void stbiw__linear_to_rgbe(unsigned char *rgbe, float *linear)
+#ifndef STBI_WRITE_NO_STDIO
+
+static void stbiw__linear_to_rgbe(unsigned char *rgbe, float *linear)
 {
    int exponent;
    float maxcomp = stbiw__max(linear[0], stbiw__max(linear[1], linear[2]));
@@ -496,7 +653,7 @@ void stbiw__linear_to_rgbe(unsigned char *rgbe, float *linear)
    }
 }
 
-void stbiw__write_run_data(stbi__write_context *s, int length, unsigned char databyte)
+static void stbiw__write_run_data(stbi__write_context *s, int length, unsigned char databyte)
 {
    unsigned char lengthbyte = STBIW_UCHAR(length+128);
    STBIW_ASSERT(length+128 <= 255);
@@ -504,7 +661,7 @@ void stbiw__write_run_data(stbi__write_context *s, int length, unsigned char dat
    s->func(s->context, &databyte, 1);
 }
 
-void stbiw__write_dump_data(stbi__write_context *s, int length, unsigned char *data)
+static void stbiw__write_dump_data(stbi__write_context *s, int length, unsigned char *data)
 {
    unsigned char lengthbyte = STBIW_UCHAR(length);
    STBIW_ASSERT(length <= 128); // inconsistent with spec but consistent with official code
@@ -512,7 +669,7 @@ void stbiw__write_dump_data(stbi__write_context *s, int length, unsigned char *d
    s->func(s->context, data, length);
 }
 
-void stbiw__write_hdr_scanline(stbi__write_context *s, int width, int ncomp, unsigned char *scratch, float *scanline)
+static void stbiw__write_hdr_scanline(stbi__write_context *s, int width, int ncomp, unsigned char *scratch, float *scanline)
 {
    unsigned char scanlineheader[4] = { 2, 2, 0, 0 };
    unsigned char rgbe[4];
@@ -613,26 +770,30 @@ static int stbi_write_hdr_core(stbi__write_context *s, int x, int y, int comp, f
       char header[] = "#?RADIANCE\n# Written by stb_image_write.h\nFORMAT=32-bit_rle_rgbe\n";
       s->func(s->context, header, sizeof(header)-1);
 
-      len = sprintf(buffer, "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
+#ifdef __STDC_LIB_EXT1__
+      len = sprintf_s(buffer, sizeof(buffer), "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
+#else
+      len = snprintf(buffer, sizeof(buffer), "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
+#endif
       s->func(s->context, buffer, len);
 
       for(i=0; i < y; i++)
-         stbiw__write_hdr_scanline(s, x, comp, scratch, data + comp*i*x);
+         stbiw__write_hdr_scanline(s, x, comp, scratch, data + comp*x*(stbi__flip_vertically_on_write ? y-1-i : i));
       STBIW_FREE(scratch);
       return 1;
    }
 }
 
-int stbi_write_hdr_to_func(stbi_write_func *func, void *context, int x, int y, int comp, const float *data)
+STBIWDEF int stbi_write_hdr_to_func(stbi_write_func *func, void *context, int x, int y, int comp, const float *data)
 {
-   stbi__write_context s;
+   stbi__write_context s = { 0 };
    stbi__start_write_callbacks(&s, func, context);
    return stbi_write_hdr_core(&s, x, y, comp, (float *) data);
 }
 
-int stbi_write_hdr(char const *filename, int x, int y, int comp, const float *data)
+STBIWDEF int stbi_write_hdr(char const *filename, int x, int y, int comp, const float *data)
 {
-   stbi__write_context s;
+   stbi__write_context s = { 0 };
    if (stbi__start_write_file(&s,filename)) {
       int r = stbi_write_hdr_core(&s, x, y, comp, (float *) data);
       stbi__end_write_file(&s);
@@ -648,8 +809,9 @@ int stbi_write_hdr(char const *filename, int x, int y, int comp, const float *da
 // PNG writer
 //
 
+#ifndef STBIW_ZLIB_COMPRESS
 // stretchy buffer; stbiw__sbpush() == vector<>::push_back() -- stbiw__sbcount() == vector<>::size()
-#define stbiw__sbraw(a) ((int *) (a) - 2)
+#define stbiw__sbraw(a) ((int *) (void *) (a) - 2)
 #define stbiw__sbm(a)   stbiw__sbraw(a)[0]
 #define stbiw__sbn(a)   stbiw__sbraw(a)[1]
 
@@ -728,8 +890,14 @@ static unsigned int stbiw__zhash(unsigned char *data)
 
 #define stbiw__ZHASH   16384
 
-unsigned char * stbi_zlib_compress(unsigned char *data, int data_len, int *out_len, int quality)
+#endif // STBIW_ZLIB_COMPRESS
+
+STBIWDEF unsigned char * stbi_zlib_compress(unsigned char *data, int data_len, int *out_len, int quality)
 {
+#ifdef STBIW_ZLIB_COMPRESS
+   // user provided a zlib compress implementation, use that
+   return STBIW_ZLIB_COMPRESS(data, data_len, out_len, quality);
+#else // use builtin
    static unsigned short lengthc[] = { 3,4,5,6,7,8,9,10,11,13,15,17,19,23,27,31,35,43,51,59,67,83,99,115,131,163,195,227,258, 259 };
    static unsigned char  lengtheb[]= { 0,0,0,0,0,0,0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4,  4,  5,  5,  5,  5,  0 };
    static unsigned short distc[]   = { 1,2,3,4,5,7,9,13,17,25,33,49,65,97,129,193,257,385,513,769,1025,1537,2049,3073,4097,6145,8193,12289,16385,24577, 32768 };
@@ -737,7 +905,9 @@ unsigned char * stbi_zlib_compress(unsigned char *data, int data_len, int *out_l
    unsigned int bitbuf=0;
    int i,j, bitcount=0;
    unsigned char *out = NULL;
-   unsigned char ***hash_table = (unsigned char***) STBIW_MALLOC(stbiw__ZHASH * sizeof(char**));
+   unsigned char ***hash_table = (unsigned char***) STBIW_MALLOC(stbiw__ZHASH * sizeof(unsigned char**));
+   if (hash_table == NULL)
+      return NULL;
    if (quality < 5) quality = 5;
 
    stbiw__sbpush(out, 0x78);   // DEFLATE 32K window
@@ -758,7 +928,7 @@ unsigned char * stbi_zlib_compress(unsigned char *data, int data_len, int *out_l
       for (j=0; j < n; ++j) {
          if (hlist[j]-data > i-32768) { // if entry lies within window
             int d = stbiw__zlib_countm(hlist[j], data+i, data_len-i);
-            if (d >= best) best=d,bestloc=hlist[j];
+            if (d >= best) { best=d; bestloc=hlist[j]; }
          }
       }
       // when hash table entry is too long, delete half the entries
@@ -811,14 +981,31 @@ unsigned char * stbi_zlib_compress(unsigned char *data, int data_len, int *out_l
       (void) stbiw__sbfree(hash_table[i]);
    STBIW_FREE(hash_table);
 
+   // store uncompressed instead if compression was worse
+   if (stbiw__sbn(out) > data_len + 2 + ((data_len+32766)/32767)*5) {
+      stbiw__sbn(out) = 2;  // truncate to DEFLATE 32K window and FLEVEL = 1
+      for (j = 0; j < data_len;) {
+         int blocklen = data_len - j;
+         if (blocklen > 32767) blocklen = 32767;
+         stbiw__sbpush(out, data_len - j == blocklen); // BFINAL = ?, BTYPE = 0 -- no compression
+         stbiw__sbpush(out, STBIW_UCHAR(blocklen)); // LEN
+         stbiw__sbpush(out, STBIW_UCHAR(blocklen >> 8));
+         stbiw__sbpush(out, STBIW_UCHAR(~blocklen)); // NLEN
+         stbiw__sbpush(out, STBIW_UCHAR(~blocklen >> 8));
+         memcpy(out+stbiw__sbn(out), data+j, blocklen);
+         stbiw__sbn(out) += blocklen;
+         j += blocklen;
+      }
+   }
+
    {
       // compute adler32 on input
       unsigned int s1=1, s2=0;
       int blocklen = (int) (data_len % 5552);
       j=0;
       while (j < data_len) {
-         for (i=0; i < blocklen; ++i) s1 += data[j+i], s2 += s1;
-         s1 %= 65521, s2 %= 65521;
+         for (i=0; i < blocklen; ++i) { s1 += data[j+i]; s2 += s1; }
+         s1 %= 65521; s2 %= 65521;
          j += blocklen;
          blocklen = 5552;
       }
@@ -831,10 +1018,14 @@ unsigned char * stbi_zlib_compress(unsigned char *data, int data_len, int *out_l
    // make returned pointer freeable
    STBIW_MEMMOVE(stbiw__sbraw(out), out, *out_len);
    return (unsigned char *) stbiw__sbraw(out);
+#endif // STBIW_ZLIB_COMPRESS
 }
 
 static unsigned int stbiw__crc32(unsigned char *buffer, int len)
 {
+#ifdef STBIW_CRC32
+    return STBIW_CRC32(buffer, len);
+#else
    static unsigned int crc_table[256] =
    {
       0x00000000, 0x77073096, 0xEE0E612C, 0x990951BA, 0x076DC419, 0x706AF48F, 0xE963A535, 0x9E6495A3,
@@ -876,6 +1067,7 @@ static unsigned int stbiw__crc32(unsigned char *buffer, int len)
    for (i=0; i < len; ++i)
       crc = (crc >> 8) ^ crc_table[buffer[i] ^ (crc & 0xff)];
    return ~crc;
+#endif
 }
 
 #define stbiw__wpng4(o,a,b,c,d) ((o)[0]=STBIW_UCHAR(a),(o)[1]=STBIW_UCHAR(b),(o)[2]=STBIW_UCHAR(c),(o)[3]=STBIW_UCHAR(d),(o)+=4)
@@ -896,61 +1088,92 @@ static unsigned char stbiw__paeth(int a, int b, int c)
    return STBIW_UCHAR(c);
 }
 
-unsigned char *stbi_write_png_to_mem(unsigned char *pixels, int stride_bytes, int x, int y, int n, int *out_len)
+// @OPTIMIZE: provide an option that always forces left-predict or paeth predict
+static void stbiw__encode_png_line(unsigned char *pixels, int stride_bytes, int width, int height, int y, int n, int filter_type, signed char *line_buffer)
 {
+   static int mapping[] = { 0,1,2,3,4 };
+   static int firstmap[] = { 0,1,0,5,6 };
+   int *mymap = (y != 0) ? mapping : firstmap;
+   int i;
+   int type = mymap[filter_type];
+   unsigned char *z = pixels + stride_bytes * (stbi__flip_vertically_on_write ? height-1-y : y);
+   int signed_stride = stbi__flip_vertically_on_write ? -stride_bytes : stride_bytes;
+
+   if (type==0) {
+      memcpy(line_buffer, z, width*n);
+      return;
+   }
+
+   // first loop isn't optimized since it's just one pixel
+   for (i = 0; i < n; ++i) {
+      switch (type) {
+         case 1: line_buffer[i] = z[i]; break;
+         case 2: line_buffer[i] = z[i] - z[i-signed_stride]; break;
+         case 3: line_buffer[i] = z[i] - (z[i-signed_stride]>>1); break;
+         case 4: line_buffer[i] = (signed char) (z[i] - stbiw__paeth(0,z[i-signed_stride],0)); break;
+         case 5: line_buffer[i] = z[i]; break;
+         case 6: line_buffer[i] = z[i]; break;
+      }
+   }
+   switch (type) {
+      case 1: for (i=n; i < width*n; ++i) line_buffer[i] = z[i] - z[i-n]; break;
+      case 2: for (i=n; i < width*n; ++i) line_buffer[i] = z[i] - z[i-signed_stride]; break;
+      case 3: for (i=n; i < width*n; ++i) line_buffer[i] = z[i] - ((z[i-n] + z[i-signed_stride])>>1); break;
+      case 4: for (i=n; i < width*n; ++i) line_buffer[i] = z[i] - stbiw__paeth(z[i-n], z[i-signed_stride], z[i-signed_stride-n]); break;
+      case 5: for (i=n; i < width*n; ++i) line_buffer[i] = z[i] - (z[i-n]>>1); break;
+      case 6: for (i=n; i < width*n; ++i) line_buffer[i] = z[i] - stbiw__paeth(z[i-n], 0,0); break;
+   }
+}
+
+STBIWDEF unsigned char *stbi_write_png_to_mem(const unsigned char *pixels, int stride_bytes, int x, int y, int n, int *out_len)
+{
+   int force_filter = stbi_write_force_png_filter;
    int ctype[5] = { -1, 0, 4, 2, 6 };
    unsigned char sig[8] = { 137,80,78,71,13,10,26,10 };
    unsigned char *out,*o, *filt, *zlib;
    signed char *line_buffer;
-   int i,j,k,p,zlen;
+   int j,zlen;
 
    if (stride_bytes == 0)
       stride_bytes = x * n;
 
+   if (force_filter >= 5) {
+      force_filter = -1;
+   }
+
    filt = (unsigned char *) STBIW_MALLOC((x*n+1) * y); if (!filt) return 0;
    line_buffer = (signed char *) STBIW_MALLOC(x * n); if (!line_buffer) { STBIW_FREE(filt); return 0; }
    for (j=0; j < y; ++j) {
-      static int mapping[] = { 0,1,2,3,4 };
-      static int firstmap[] = { 0,1,0,5,6 };
-      int *mymap = j ? mapping : firstmap;
-      int best = 0, bestval = 0x7fffffff;
-      for (p=0; p < 2; ++p) {
-         for (k= p?best:0; k < 5; ++k) {
-            int type = mymap[k],est=0;
-            unsigned char *z = pixels + stride_bytes*j;
-            for (i=0; i < n; ++i)
-               switch (type) {
-                  case 0: line_buffer[i] = z[i]; break;
-                  case 1: line_buffer[i] = z[i]; break;
-                  case 2: line_buffer[i] = z[i] - z[i-stride_bytes]; break;
-                  case 3: line_buffer[i] = z[i] - (z[i-stride_bytes]>>1); break;
-                  case 4: line_buffer[i] = (signed char) (z[i] - stbiw__paeth(0,z[i-stride_bytes],0)); break;
-                  case 5: line_buffer[i] = z[i]; break;
-                  case 6: line_buffer[i] = z[i]; break;
-               }
-            for (i=n; i < x*n; ++i) {
-               switch (type) {
-                  case 0: line_buffer[i] = z[i]; break;
-                  case 1: line_buffer[i] = z[i] - z[i-n]; break;
-                  case 2: line_buffer[i] = z[i] - z[i-stride_bytes]; break;
-                  case 3: line_buffer[i] = z[i] - ((z[i-n] + z[i-stride_bytes])>>1); break;
-                  case 4: line_buffer[i] = z[i] - stbiw__paeth(z[i-n], z[i-stride_bytes], z[i-stride_bytes-n]); break;
-                  case 5: line_buffer[i] = z[i] - (z[i-n]>>1); break;
-                  case 6: line_buffer[i] = z[i] - stbiw__paeth(z[i-n], 0,0); break;
-               }
-            }
-            if (p) break;
-            for (i=0; i < x*n; ++i)
+      int filter_type;
+      if (force_filter > -1) {
+         filter_type = force_filter;
+         stbiw__encode_png_line((unsigned char*)(pixels), stride_bytes, x, y, j, n, force_filter, line_buffer);
+      } else { // Estimate the best filter by running through all of them:
+         int best_filter = 0, best_filter_val = 0x7fffffff, est, i;
+         for (filter_type = 0; filter_type < 5; filter_type++) {
+            stbiw__encode_png_line((unsigned char*)(pixels), stride_bytes, x, y, j, n, filter_type, line_buffer);
+
+            // Estimate the entropy of the line using this filter; the less, the better.
+            est = 0;
+            for (i = 0; i < x*n; ++i) {
                est += abs((signed char) line_buffer[i]);
-            if (est < bestval) { bestval = est; best = k; }
+            }
+            if (est < best_filter_val) {
+               best_filter_val = est;
+               best_filter = filter_type;
+            }
+         }
+         if (filter_type != best_filter) {  // If the last iteration already got us the best filter, don't redo it
+            stbiw__encode_png_line((unsigned char*)(pixels), stride_bytes, x, y, j, n, best_filter, line_buffer);
+            filter_type = best_filter;
          }
       }
-      // when we get here, best contains the filter type, and line_buffer contains the data
-      filt[j*(x*n+1)] = (unsigned char) best;
+      // when we get here, filter_type contains the filter type, and line_buffer contains the data
+      filt[j*(x*n+1)] = (unsigned char) filter_type;
       STBIW_MEMMOVE(filt+j*(x*n+1)+1, line_buffer, x*n);
    }
    STBIW_FREE(line_buffer);
-   zlib = stbi_zlib_compress(filt, y*( x*n+1), &zlen, 8); // increase 8 to get smaller but use more memory
+   zlib = stbi_zlib_compress(filt, y*( x*n+1), &zlen, stbi_write_png_compression_level);
    STBIW_FREE(filt);
    if (!zlib) return 0;
 
@@ -993,9 +1216,10 @@ STBIWDEF int stbi_write_png(char const *filename, int x, int y, int comp, const 
 {
    FILE *f;
    int len;
-   unsigned char *png = stbi_write_png_to_mem((unsigned char *) data, stride_bytes, x, y, comp, &len);
+   unsigned char *png = stbi_write_png_to_mem((const unsigned char *) data, stride_bytes, x, y, comp, &len);
    if (png == NULL) return 0;
-   f = fopen(filename, "wb");
+
+   f = stbiw__fopen(filename, "wb");
    if (!f) { STBIW_FREE(png); return 0; }
    fwrite(png, 1, len, f);
    fclose(f);
@@ -1007,16 +1231,426 @@ STBIWDEF int stbi_write_png(char const *filename, int x, int y, int comp, const 
 STBIWDEF int stbi_write_png_to_func(stbi_write_func *func, void *context, int x, int y, int comp, const void *data, int stride_bytes)
 {
    int len;
-   unsigned char *png = stbi_write_png_to_mem((unsigned char *) data, stride_bytes, x, y, comp, &len);
+   unsigned char *png = stbi_write_png_to_mem((const unsigned char *) data, stride_bytes, x, y, comp, &len);
    if (png == NULL) return 0;
    func(context, png, len);
    STBIW_FREE(png);
    return 1;
 }
 
+
+/* ***************************************************************************
+ *
+ * JPEG writer
+ *
+ * This is based on Jon Olick's jo_jpeg.cpp:
+ * public domain Simple, Minimalistic JPEG writer - http://www.jonolick.com/code.html
+ */
+
+static const unsigned char stbiw__jpg_ZigZag[] = { 0,1,5,6,14,15,27,28,2,4,7,13,16,26,29,42,3,8,12,17,25,30,41,43,9,11,18,
+      24,31,40,44,53,10,19,23,32,39,45,52,54,20,22,33,38,46,51,55,60,21,34,37,47,50,56,59,61,35,36,48,49,57,58,62,63 };
+
+static void stbiw__jpg_writeBits(stbi__write_context *s, int *bitBufP, int *bitCntP, const unsigned short *bs) {
+   int bitBuf = *bitBufP, bitCnt = *bitCntP;
+   bitCnt += bs[1];
+   bitBuf |= bs[0] << (24 - bitCnt);
+   while(bitCnt >= 8) {
+      unsigned char c = (bitBuf >> 16) & 255;
+      stbiw__putc(s, c);
+      if(c == 255) {
+         stbiw__putc(s, 0);
+      }
+      bitBuf <<= 8;
+      bitCnt -= 8;
+   }
+   *bitBufP = bitBuf;
+   *bitCntP = bitCnt;
+}
+
+static void stbiw__jpg_DCT(float *d0p, float *d1p, float *d2p, float *d3p, float *d4p, float *d5p, float *d6p, float *d7p) {
+   float d0 = *d0p, d1 = *d1p, d2 = *d2p, d3 = *d3p, d4 = *d4p, d5 = *d5p, d6 = *d6p, d7 = *d7p;
+   float z1, z2, z3, z4, z5, z11, z13;
+
+   float tmp0 = d0 + d7;
+   float tmp7 = d0 - d7;
+   float tmp1 = d1 + d6;
+   float tmp6 = d1 - d6;
+   float tmp2 = d2 + d5;
+   float tmp5 = d2 - d5;
+   float tmp3 = d3 + d4;
+   float tmp4 = d3 - d4;
+
+   // Even part
+   float tmp10 = tmp0 + tmp3;   // phase 2
+   float tmp13 = tmp0 - tmp3;
+   float tmp11 = tmp1 + tmp2;
+   float tmp12 = tmp1 - tmp2;
+
+   d0 = tmp10 + tmp11;       // phase 3
+   d4 = tmp10 - tmp11;
+
+   z1 = (tmp12 + tmp13) * 0.707106781f; // c4
+   d2 = tmp13 + z1;       // phase 5
+   d6 = tmp13 - z1;
+
+   // Odd part
+   tmp10 = tmp4 + tmp5;       // phase 2
+   tmp11 = tmp5 + tmp6;
+   tmp12 = tmp6 + tmp7;
+
+   // The rotator is modified from fig 4-8 to avoid extra negations.
+   z5 = (tmp10 - tmp12) * 0.382683433f; // c6
+   z2 = tmp10 * 0.541196100f + z5; // c2-c6
+   z4 = tmp12 * 1.306562965f + z5; // c2+c6
+   z3 = tmp11 * 0.707106781f; // c4
+
+   z11 = tmp7 + z3;      // phase 5
+   z13 = tmp7 - z3;
+
+   *d5p = z13 + z2;         // phase 6
+   *d3p = z13 - z2;
+   *d1p = z11 + z4;
+   *d7p = z11 - z4;
+
+   *d0p = d0;  *d2p = d2;  *d4p = d4;  *d6p = d6;
+}
+
+static void stbiw__jpg_calcBits(int val, unsigned short bits[2]) {
+   int tmp1 = val < 0 ? -val : val;
+   val = val < 0 ? val-1 : val;
+   bits[1] = 1;
+   while(tmp1 >>= 1) {
+      ++bits[1];
+   }
+   bits[0] = val & ((1<<bits[1])-1);
+}
+
+static int stbiw__jpg_processDU(stbi__write_context *s, int *bitBuf, int *bitCnt, float *CDU, int du_stride, float *fdtbl, int DC, const unsigned short HTDC[256][2], const unsigned short HTAC[256][2]) {
+   const unsigned short EOB[2] = { HTAC[0x00][0], HTAC[0x00][1] };
+   const unsigned short M16zeroes[2] = { HTAC[0xF0][0], HTAC[0xF0][1] };
+   int dataOff, i, j, n, diff, end0pos, x, y;
+   int DU[64];
+
+   // DCT rows
+   for(dataOff=0, n=du_stride*8; dataOff<n; dataOff+=du_stride) {
+      stbiw__jpg_DCT(&CDU[dataOff], &CDU[dataOff+1], &CDU[dataOff+2], &CDU[dataOff+3], &CDU[dataOff+4], &CDU[dataOff+5], &CDU[dataOff+6], &CDU[dataOff+7]);
+   }
+   // DCT columns
+   for(dataOff=0; dataOff<8; ++dataOff) {
+      stbiw__jpg_DCT(&CDU[dataOff], &CDU[dataOff+du_stride], &CDU[dataOff+du_stride*2], &CDU[dataOff+du_stride*3], &CDU[dataOff+du_stride*4],
+                     &CDU[dataOff+du_stride*5], &CDU[dataOff+du_stride*6], &CDU[dataOff+du_stride*7]);
+   }
+   // Quantize/descale/zigzag the coefficients
+   for(y = 0, j=0; y < 8; ++y) {
+      for(x = 0; x < 8; ++x,++j) {
+         float v;
+         i = y*du_stride+x;
+         v = CDU[i]*fdtbl[j];
+         // DU[stbiw__jpg_ZigZag[j]] = (int)(v < 0 ? ceilf(v - 0.5f) : floorf(v + 0.5f));
+         // ceilf() and floorf() are C99, not C89, but I /think/ they're not needed here anyway?
+         DU[stbiw__jpg_ZigZag[j]] = (int)(v < 0 ? v - 0.5f : v + 0.5f);
+      }
+   }
+
+   // Encode DC
+   diff = DU[0] - DC;
+   if (diff == 0) {
+      stbiw__jpg_writeBits(s, bitBuf, bitCnt, HTDC[0]);
+   } else {
+      unsigned short bits[2];
+      stbiw__jpg_calcBits(diff, bits);
+      stbiw__jpg_writeBits(s, bitBuf, bitCnt, HTDC[bits[1]]);
+      stbiw__jpg_writeBits(s, bitBuf, bitCnt, bits);
+   }
+   // Encode ACs
+   end0pos = 63;
+   for(; (end0pos>0)&&(DU[end0pos]==0); --end0pos) {
+   }
+   // end0pos = first element in reverse order !=0
+   if(end0pos == 0) {
+      stbiw__jpg_writeBits(s, bitBuf, bitCnt, EOB);
+      return DU[0];
+   }
+   for(i = 1; i <= end0pos; ++i) {
+      int startpos = i;
+      int nrzeroes;
+      unsigned short bits[2];
+      for (; DU[i]==0 && i<=end0pos; ++i) {
+      }
+      nrzeroes = i-startpos;
+      if ( nrzeroes >= 16 ) {
+         int lng = nrzeroes>>4;
+         int nrmarker;
+         for (nrmarker=1; nrmarker <= lng; ++nrmarker)
+            stbiw__jpg_writeBits(s, bitBuf, bitCnt, M16zeroes);
+         nrzeroes &= 15;
+      }
+      stbiw__jpg_calcBits(DU[i], bits);
+      stbiw__jpg_writeBits(s, bitBuf, bitCnt, HTAC[(nrzeroes<<4)+bits[1]]);
+      stbiw__jpg_writeBits(s, bitBuf, bitCnt, bits);
+   }
+   if(end0pos != 63) {
+      stbiw__jpg_writeBits(s, bitBuf, bitCnt, EOB);
+   }
+   return DU[0];
+}
+
+static int stbi_write_jpg_core(stbi__write_context *s, int width, int height, int comp, const void* data, int quality) {
+   // Constants that don't pollute global namespace
+   static const unsigned char std_dc_luminance_nrcodes[] = {0,0,1,5,1,1,1,1,1,1,0,0,0,0,0,0,0};
+   static const unsigned char std_dc_luminance_values[] = {0,1,2,3,4,5,6,7,8,9,10,11};
+   static const unsigned char std_ac_luminance_nrcodes[] = {0,0,2,1,3,3,2,4,3,5,5,4,4,0,0,1,0x7d};
+   static const unsigned char std_ac_luminance_values[] = {
+      0x01,0x02,0x03,0x00,0x04,0x11,0x05,0x12,0x21,0x31,0x41,0x06,0x13,0x51,0x61,0x07,0x22,0x71,0x14,0x32,0x81,0x91,0xa1,0x08,
+      0x23,0x42,0xb1,0xc1,0x15,0x52,0xd1,0xf0,0x24,0x33,0x62,0x72,0x82,0x09,0x0a,0x16,0x17,0x18,0x19,0x1a,0x25,0x26,0x27,0x28,
+      0x29,0x2a,0x34,0x35,0x36,0x37,0x38,0x39,0x3a,0x43,0x44,0x45,0x46,0x47,0x48,0x49,0x4a,0x53,0x54,0x55,0x56,0x57,0x58,0x59,
+      0x5a,0x63,0x64,0x65,0x66,0x67,0x68,0x69,0x6a,0x73,0x74,0x75,0x76,0x77,0x78,0x79,0x7a,0x83,0x84,0x85,0x86,0x87,0x88,0x89,
+      0x8a,0x92,0x93,0x94,0x95,0x96,0x97,0x98,0x99,0x9a,0xa2,0xa3,0xa4,0xa5,0xa6,0xa7,0xa8,0xa9,0xaa,0xb2,0xb3,0xb4,0xb5,0xb6,
+      0xb7,0xb8,0xb9,0xba,0xc2,0xc3,0xc4,0xc5,0xc6,0xc7,0xc8,0xc9,0xca,0xd2,0xd3,0xd4,0xd5,0xd6,0xd7,0xd8,0xd9,0xda,0xe1,0xe2,
+      0xe3,0xe4,0xe5,0xe6,0xe7,0xe8,0xe9,0xea,0xf1,0xf2,0xf3,0xf4,0xf5,0xf6,0xf7,0xf8,0xf9,0xfa
+   };
+   static const unsigned char std_dc_chrominance_nrcodes[] = {0,0,3,1,1,1,1,1,1,1,1,1,0,0,0,0,0};
+   static const unsigned char std_dc_chrominance_values[] = {0,1,2,3,4,5,6,7,8,9,10,11};
+   static const unsigned char std_ac_chrominance_nrcodes[] = {0,0,2,1,2,4,4,3,4,7,5,4,4,0,1,2,0x77};
+   static const unsigned char std_ac_chrominance_values[] = {
+      0x00,0x01,0x02,0x03,0x11,0x04,0x05,0x21,0x31,0x06,0x12,0x41,0x51,0x07,0x61,0x71,0x13,0x22,0x32,0x81,0x08,0x14,0x42,0x91,
+      0xa1,0xb1,0xc1,0x09,0x23,0x33,0x52,0xf0,0x15,0x62,0x72,0xd1,0x0a,0x16,0x24,0x34,0xe1,0x25,0xf1,0x17,0x18,0x19,0x1a,0x26,
+      0x27,0x28,0x29,0x2a,0x35,0x36,0x37,0x38,0x39,0x3a,0x43,0x44,0x45,0x46,0x47,0x48,0x49,0x4a,0x53,0x54,0x55,0x56,0x57,0x58,
+      0x59,0x5a,0x63,0x64,0x65,0x66,0x67,0x68,0x69,0x6a,0x73,0x74,0x75,0x76,0x77,0x78,0x79,0x7a,0x82,0x83,0x84,0x85,0x86,0x87,
+      0x88,0x89,0x8a,0x92,0x93,0x94,0x95,0x96,0x97,0x98,0x99,0x9a,0xa2,0xa3,0xa4,0xa5,0xa6,0xa7,0xa8,0xa9,0xaa,0xb2,0xb3,0xb4,
+      0xb5,0xb6,0xb7,0xb8,0xb9,0xba,0xc2,0xc3,0xc4,0xc5,0xc6,0xc7,0xc8,0xc9,0xca,0xd2,0xd3,0xd4,0xd5,0xd6,0xd7,0xd8,0xd9,0xda,
+      0xe2,0xe3,0xe4,0xe5,0xe6,0xe7,0xe8,0xe9,0xea,0xf2,0xf3,0xf4,0xf5,0xf6,0xf7,0xf8,0xf9,0xfa
+   };
+   // Huffman tables
+   static const unsigned short YDC_HT[256][2] = { {0,2},{2,3},{3,3},{4,3},{5,3},{6,3},{14,4},{30,5},{62,6},{126,7},{254,8},{510,9}};
+   static const unsigned short UVDC_HT[256][2] = { {0,2},{1,2},{2,2},{6,3},{14,4},{30,5},{62,6},{126,7},{254,8},{510,9},{1022,10},{2046,11}};
+   static const unsigned short YAC_HT[256][2] = {
+      {10,4},{0,2},{1,2},{4,3},{11,4},{26,5},{120,7},{248,8},{1014,10},{65410,16},{65411,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {12,4},{27,5},{121,7},{502,9},{2038,11},{65412,16},{65413,16},{65414,16},{65415,16},{65416,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {28,5},{249,8},{1015,10},{4084,12},{65417,16},{65418,16},{65419,16},{65420,16},{65421,16},{65422,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {58,6},{503,9},{4085,12},{65423,16},{65424,16},{65425,16},{65426,16},{65427,16},{65428,16},{65429,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {59,6},{1016,10},{65430,16},{65431,16},{65432,16},{65433,16},{65434,16},{65435,16},{65436,16},{65437,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {122,7},{2039,11},{65438,16},{65439,16},{65440,16},{65441,16},{65442,16},{65443,16},{65444,16},{65445,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {123,7},{4086,12},{65446,16},{65447,16},{65448,16},{65449,16},{65450,16},{65451,16},{65452,16},{65453,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {250,8},{4087,12},{65454,16},{65455,16},{65456,16},{65457,16},{65458,16},{65459,16},{65460,16},{65461,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {504,9},{32704,15},{65462,16},{65463,16},{65464,16},{65465,16},{65466,16},{65467,16},{65468,16},{65469,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {505,9},{65470,16},{65471,16},{65472,16},{65473,16},{65474,16},{65475,16},{65476,16},{65477,16},{65478,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {506,9},{65479,16},{65480,16},{65481,16},{65482,16},{65483,16},{65484,16},{65485,16},{65486,16},{65487,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {1017,10},{65488,16},{65489,16},{65490,16},{65491,16},{65492,16},{65493,16},{65494,16},{65495,16},{65496,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {1018,10},{65497,16},{65498,16},{65499,16},{65500,16},{65501,16},{65502,16},{65503,16},{65504,16},{65505,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {2040,11},{65506,16},{65507,16},{65508,16},{65509,16},{65510,16},{65511,16},{65512,16},{65513,16},{65514,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {65515,16},{65516,16},{65517,16},{65518,16},{65519,16},{65520,16},{65521,16},{65522,16},{65523,16},{65524,16},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {2041,11},{65525,16},{65526,16},{65527,16},{65528,16},{65529,16},{65530,16},{65531,16},{65532,16},{65533,16},{65534,16},{0,0},{0,0},{0,0},{0,0},{0,0}
+   };
+   static const unsigned short UVAC_HT[256][2] = {
+      {0,2},{1,2},{4,3},{10,4},{24,5},{25,5},{56,6},{120,7},{500,9},{1014,10},{4084,12},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {11,4},{57,6},{246,8},{501,9},{2038,11},{4085,12},{65416,16},{65417,16},{65418,16},{65419,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {26,5},{247,8},{1015,10},{4086,12},{32706,15},{65420,16},{65421,16},{65422,16},{65423,16},{65424,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {27,5},{248,8},{1016,10},{4087,12},{65425,16},{65426,16},{65427,16},{65428,16},{65429,16},{65430,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {58,6},{502,9},{65431,16},{65432,16},{65433,16},{65434,16},{65435,16},{65436,16},{65437,16},{65438,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {59,6},{1017,10},{65439,16},{65440,16},{65441,16},{65442,16},{65443,16},{65444,16},{65445,16},{65446,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {121,7},{2039,11},{65447,16},{65448,16},{65449,16},{65450,16},{65451,16},{65452,16},{65453,16},{65454,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {122,7},{2040,11},{65455,16},{65456,16},{65457,16},{65458,16},{65459,16},{65460,16},{65461,16},{65462,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {249,8},{65463,16},{65464,16},{65465,16},{65466,16},{65467,16},{65468,16},{65469,16},{65470,16},{65471,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {503,9},{65472,16},{65473,16},{65474,16},{65475,16},{65476,16},{65477,16},{65478,16},{65479,16},{65480,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {504,9},{65481,16},{65482,16},{65483,16},{65484,16},{65485,16},{65486,16},{65487,16},{65488,16},{65489,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {505,9},{65490,16},{65491,16},{65492,16},{65493,16},{65494,16},{65495,16},{65496,16},{65497,16},{65498,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {506,9},{65499,16},{65500,16},{65501,16},{65502,16},{65503,16},{65504,16},{65505,16},{65506,16},{65507,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {2041,11},{65508,16},{65509,16},{65510,16},{65511,16},{65512,16},{65513,16},{65514,16},{65515,16},{65516,16},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {16352,14},{65517,16},{65518,16},{65519,16},{65520,16},{65521,16},{65522,16},{65523,16},{65524,16},{65525,16},{0,0},{0,0},{0,0},{0,0},{0,0},
+      {1018,10},{32707,15},{65526,16},{65527,16},{65528,16},{65529,16},{65530,16},{65531,16},{65532,16},{65533,16},{65534,16},{0,0},{0,0},{0,0},{0,0},{0,0}
+   };
+   static const int YQT[] = {16,11,10,16,24,40,51,61,12,12,14,19,26,58,60,55,14,13,16,24,40,57,69,56,14,17,22,29,51,87,80,62,18,22,
+                             37,56,68,109,103,77,24,35,55,64,81,104,113,92,49,64,78,87,103,121,120,101,72,92,95,98,112,100,103,99};
+   static const int UVQT[] = {17,18,24,47,99,99,99,99,18,21,26,66,99,99,99,99,24,26,56,99,99,99,99,99,47,66,99,99,99,99,99,99,
+                              99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99};
+   static const float aasf[] = { 1.0f * 2.828427125f, 1.387039845f * 2.828427125f, 1.306562965f * 2.828427125f, 1.175875602f * 2.828427125f,
+                                 1.0f * 2.828427125f, 0.785694958f * 2.828427125f, 0.541196100f * 2.828427125f, 0.275899379f * 2.828427125f };
+
+   int row, col, i, k, subsample;
+   float fdtbl_Y[64], fdtbl_UV[64];
+   unsigned char YTable[64], UVTable[64];
+
+   if(!data || !width || !height || comp > 4 || comp < 1) {
+      return 0;
+   }
+
+   quality = quality ? quality : 90;
+   subsample = quality <= 90 ? 1 : 0;
+   quality = quality < 1 ? 1 : quality > 100 ? 100 : quality;
+   quality = quality < 50 ? 5000 / quality : 200 - quality * 2;
+
+   for(i = 0; i < 64; ++i) {
+      int uvti, yti = (YQT[i]*quality+50)/100;
+      YTable[stbiw__jpg_ZigZag[i]] = (unsigned char) (yti < 1 ? 1 : yti > 255 ? 255 : yti);
+      uvti = (UVQT[i]*quality+50)/100;
+      UVTable[stbiw__jpg_ZigZag[i]] = (unsigned char) (uvti < 1 ? 1 : uvti > 255 ? 255 : uvti);
+   }
+
+   for(row = 0, k = 0; row < 8; ++row) {
+      for(col = 0; col < 8; ++col, ++k) {
+         fdtbl_Y[k]  = 1 / (YTable [stbiw__jpg_ZigZag[k]] * aasf[row] * aasf[col]);
+         fdtbl_UV[k] = 1 / (UVTable[stbiw__jpg_ZigZag[k]] * aasf[row] * aasf[col]);
+      }
+   }
+
+   // Write Headers
+   {
+      static const unsigned char head0[] = { 0xFF,0xD8,0xFF,0xE0,0,0x10,'J','F','I','F',0,1,1,0,0,1,0,1,0,0,0xFF,0xDB,0,0x84,0 };
+      static const unsigned char head2[] = { 0xFF,0xDA,0,0xC,3,1,0,2,0x11,3,0x11,0,0x3F,0 };
+      const unsigned char head1[] = { 0xFF,0xC0,0,0x11,8,(unsigned char)(height>>8),STBIW_UCHAR(height),(unsigned char)(width>>8),STBIW_UCHAR(width),
+                                      3,1,(unsigned char)(subsample?0x22:0x11),0,2,0x11,1,3,0x11,1,0xFF,0xC4,0x01,0xA2,0 };
+      s->func(s->context, (void*)head0, sizeof(head0));
+      s->func(s->context, (void*)YTable, sizeof(YTable));
+      stbiw__putc(s, 1);
+      s->func(s->context, UVTable, sizeof(UVTable));
+      s->func(s->context, (void*)head1, sizeof(head1));
+      s->func(s->context, (void*)(std_dc_luminance_nrcodes+1), sizeof(std_dc_luminance_nrcodes)-1);
+      s->func(s->context, (void*)std_dc_luminance_values, sizeof(std_dc_luminance_values));
+      stbiw__putc(s, 0x10); // HTYACinfo
+      s->func(s->context, (void*)(std_ac_luminance_nrcodes+1), sizeof(std_ac_luminance_nrcodes)-1);
+      s->func(s->context, (void*)std_ac_luminance_values, sizeof(std_ac_luminance_values));
+      stbiw__putc(s, 1); // HTUDCinfo
+      s->func(s->context, (void*)(std_dc_chrominance_nrcodes+1), sizeof(std_dc_chrominance_nrcodes)-1);
+      s->func(s->context, (void*)std_dc_chrominance_values, sizeof(std_dc_chrominance_values));
+      stbiw__putc(s, 0x11); // HTUACinfo
+      s->func(s->context, (void*)(std_ac_chrominance_nrcodes+1), sizeof(std_ac_chrominance_nrcodes)-1);
+      s->func(s->context, (void*)std_ac_chrominance_values, sizeof(std_ac_chrominance_values));
+      s->func(s->context, (void*)head2, sizeof(head2));
+   }
+
+   // Encode 8x8 macroblocks
+   {
+      static const unsigned short fillBits[] = {0x7F, 7};
+      int DCY=0, DCU=0, DCV=0;
+      int bitBuf=0, bitCnt=0;
+      // comp == 2 is grey+alpha (alpha is ignored)
+      int ofsG = comp > 2 ? 1 : 0, ofsB = comp > 2 ? 2 : 0;
+      const unsigned char *dataR = (const unsigned char *)data;
+      const unsigned char *dataG = dataR + ofsG;
+      const unsigned char *dataB = dataR + ofsB;
+      int x, y, pos;
+      if(subsample) {
+         for(y = 0; y < height; y += 16) {
+            for(x = 0; x < width; x += 16) {
+               float Y[256], U[256], V[256];
+               for(row = y, pos = 0; row < y+16; ++row) {
+                  // row >= height => use last input row
+                  int clamped_row = (row < height) ? row : height - 1;
+                  int base_p = (stbi__flip_vertically_on_write ? (height-1-clamped_row) : clamped_row)*width*comp;
+                  for(col = x; col < x+16; ++col, ++pos) {
+                     // if col >= width => use pixel from last input column
+                     int p = base_p + ((col < width) ? col : (width-1))*comp;
+                     float r = dataR[p], g = dataG[p], b = dataB[p];
+                     Y[pos]= +0.29900f*r + 0.58700f*g + 0.11400f*b - 128;
+                     U[pos]= -0.16874f*r - 0.33126f*g + 0.50000f*b;
+                     V[pos]= +0.50000f*r - 0.41869f*g - 0.08131f*b;
+                  }
+               }
+               DCY = stbiw__jpg_processDU(s, &bitBuf, &bitCnt, Y+0,   16, fdtbl_Y, DCY, YDC_HT, YAC_HT);
+               DCY = stbiw__jpg_processDU(s, &bitBuf, &bitCnt, Y+8,   16, fdtbl_Y, DCY, YDC_HT, YAC_HT);
+               DCY = stbiw__jpg_processDU(s, &bitBuf, &bitCnt, Y+128, 16, fdtbl_Y, DCY, YDC_HT, YAC_HT);
+               DCY = stbiw__jpg_processDU(s, &bitBuf, &bitCnt, Y+136, 16, fdtbl_Y, DCY, YDC_HT, YAC_HT);
+
+               // subsample U,V
+               {
+                  float subU[64], subV[64];
+                  int yy, xx;
+                  for(yy = 0, pos = 0; yy < 8; ++yy) {
+                     for(xx = 0; xx < 8; ++xx, ++pos) {
+                        int j = yy*32+xx*2;
+                        subU[pos] = (U[j+0] + U[j+1] + U[j+16] + U[j+17]) * 0.25f;
+                        subV[pos] = (V[j+0] + V[j+1] + V[j+16] + V[j+17]) * 0.25f;
+                     }
+                  }
+                  DCU = stbiw__jpg_processDU(s, &bitBuf, &bitCnt, subU, 8, fdtbl_UV, DCU, UVDC_HT, UVAC_HT);
+                  DCV = stbiw__jpg_processDU(s, &bitBuf, &bitCnt, subV, 8, fdtbl_UV, DCV, UVDC_HT, UVAC_HT);
+               }
+            }
+         }
+      } else {
+         for(y = 0; y < height; y += 8) {
+            for(x = 0; x < width; x += 8) {
+               float Y[64], U[64], V[64];
+               for(row = y, pos = 0; row < y+8; ++row) {
+                  // row >= height => use last input row
+                  int clamped_row = (row < height) ? row : height - 1;
+                  int base_p = (stbi__flip_vertically_on_write ? (height-1-clamped_row) : clamped_row)*width*comp;
+                  for(col = x; col < x+8; ++col, ++pos) {
+                     // if col >= width => use pixel from last input column
+                     int p = base_p + ((col < width) ? col : (width-1))*comp;
+                     float r = dataR[p], g = dataG[p], b = dataB[p];
+                     Y[pos]= +0.29900f*r + 0.58700f*g + 0.11400f*b - 128;
+                     U[pos]= -0.16874f*r - 0.33126f*g + 0.50000f*b;
+                     V[pos]= +0.50000f*r - 0.41869f*g - 0.08131f*b;
+                  }
+               }
+
+               DCY = stbiw__jpg_processDU(s, &bitBuf, &bitCnt, Y, 8, fdtbl_Y,  DCY, YDC_HT, YAC_HT);
+               DCU = stbiw__jpg_processDU(s, &bitBuf, &bitCnt, U, 8, fdtbl_UV, DCU, UVDC_HT, UVAC_HT);
+               DCV = stbiw__jpg_processDU(s, &bitBuf, &bitCnt, V, 8, fdtbl_UV, DCV, UVDC_HT, UVAC_HT);
+            }
+         }
+      }
+
+      // Do the bit alignment of the EOI marker
+      stbiw__jpg_writeBits(s, &bitBuf, &bitCnt, fillBits);
+   }
+
+   // EOI
+   stbiw__putc(s, 0xFF);
+   stbiw__putc(s, 0xD9);
+
+   return 1;
+}
+
+STBIWDEF int stbi_write_jpg_to_func(stbi_write_func *func, void *context, int x, int y, int comp, const void *data, int quality)
+{
+   stbi__write_context s = { 0 };
+   stbi__start_write_callbacks(&s, func, context);
+   return stbi_write_jpg_core(&s, x, y, comp, (void *) data, quality);
+}
+
+
+#ifndef STBI_WRITE_NO_STDIO
+STBIWDEF int stbi_write_jpg(char const *filename, int x, int y, int comp, const void *data, int quality)
+{
+   stbi__write_context s = { 0 };
+   if (stbi__start_write_file(&s,filename)) {
+      int r = stbi_write_jpg_core(&s, x, y, comp, data, quality);
+      stbi__end_write_file(&s);
+      return r;
+   } else
+      return 0;
+}
+#endif
+
 #endif // STB_IMAGE_WRITE_IMPLEMENTATION
 
 /* Revision history
+      1.16  (2021-07-11)
+             make Deflate code emit uncompressed blocks when it would otherwise expand
+             support writing BMPs with alpha channel
+      1.15  (2020-07-13) unknown
+      1.14  (2020-02-02) updated JPEG writer to downsample chroma channels
+      1.13
+      1.12
+      1.11  (2019-08-11)
+
+      1.10  (2019-02-07)
+             support utf8 filenames in Windows; fix warnings and platform ifdefs
+      1.09  (2018-02-11)
+             fix typo in zlib quality API, improve STB_I_W_STATIC in C++
+      1.08  (2018-01-29)
+             add stbi__flip_vertically_on_write, external zlib, zlib quality, choose PNG filter
+      1.07  (2017-07-24)
+             doc fix
+      1.06 (2017-07-23)
+             writing JPEG (using Jon Olick's code)
+      1.05   ???
+      1.04 (2017-03-03)
+             monochrome BMP expansion
+      1.03   ???
       1.02 (2016-04-02)
              avoid allocating large structures on the stack
       1.01 (2016-01-16)
@@ -1045,4 +1679,46 @@ STBIWDEF int stbi_write_png_to_func(stbi_write_func *func, void *context, int x,
       0.91 (2010-07-17)
              first public release
       0.90   first internal release
+*/
+
+/*
+------------------------------------------------------------------------------
+This software is available under 2 licenses -- choose whichever you prefer.
+------------------------------------------------------------------------------
+ALTERNATIVE A - MIT License
+Copyright (c) 2017 Sean Barrett
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+------------------------------------------------------------------------------
+ALTERNATIVE B - Public Domain (www.unlicense.org)
+This is free and unencumbered software released into the public domain.
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute this
+software, either in source code form or as a compiled binary, for any purpose,
+commercial or non-commercial, and by any means.
+In jurisdictions that recognize copyright laws, the author or authors of this
+software dedicate any and all copyright interest in the software to the public
+domain. We make this dedication for the benefit of the public at large and to
+the detriment of our heirs and successors. We intend this dedication to be an
+overt act of relinquishment in perpetuity of all present and future rights to
+this software under copyright law.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+------------------------------------------------------------------------------
 */

--- a/test/compile.sh
+++ b/test/compile.sh
@@ -40,7 +40,7 @@ CCFLAGS="${ARCH} ${ASAN_FLAGS} -g -O1 -DJC_TEST_USE_COLORS -Wall -Weverything -W
 CFLAGS="-c $CFLAGS -std=${STDVERSION} ${CCFLAGS}"
 CXXFLAGS="$CXXFLAGS -std=c++11 -Wno-global-constructors -Wno-weak-vtables -Wno-old-style-cast -Wno-zero-as-null-pointer-constant -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-suggest-override"
 LINKFLAGS="-lm ${ASAN_LDFLAGS}"
-DOUBLEDEFINES="-Wno-double-promotion -DTEST_USE_DOUBLE -DJCV_REAL_TYPE=double -DJCV_ATAN2=atan2 -DJCV_SQRT=sqrt -DJCV_REAL_TYPE_EPSILON=DBL_EPSILON"
+DOUBLEDEFINES="-Wno-double-promotion -DTEST_USE_DOUBLE -DJCV_USE_DOUBLE=1 -DJCV_REAL_TYPE=double -DJCV_ATAN2=atan2 -DJCV_SQRT=sqrt -DJCV_REAL_TYPE_EPSILON=DBL_EPSILON"
 
 ${CXX} -o ../build/test $CCFLAGS $CXXFLAGS $LINKFLAGS test.cpp
 ${CXX} -o ../build/test_double $CCFLAGS $CXXFLAGS $LINKFLAGS $DOUBLEDEFINES test.cpp

--- a/test/perftest.cpp
+++ b/test/perftest.cpp
@@ -91,32 +91,33 @@ struct Context
 
 #define MAP_DIMENSION 4096
 
-void setup_sites(int count, Context* context)
+void fill_random_sites(PointF* sites, int count)
 {
-	context->count = count;
-	context->fsites = new PointF[count];
-	context->dsites = new PointD[count];
-	context->sitesx = new float[count];
-	context->sitesy = new float[count];
-	context->dpoints.resize(count);
-#if defined(USE_VORONOIPP)
-	context->vpp_sites.resize(count);
-#endif
-#if defined(USE_BOOST)
-	context->boost_points.resize(count);
-#endif
-
-	context->dgmin = PointF(FLT_MAX, FLT_MAX);
-	context->dgmax = PointF(-FLT_MAX, -FLT_MAX);
-
-    int pointoffset = 10; // move the points inwards, for aestetic reasons
+	const int pointoffset = 10; // move the points inwards, for aesthetic reasons
 	srand(0);
 	for( int i = 0; i < count; ++i )
 	{
-		float x = float(pointoffset + rand() % (MAP_DIMENSION-2*pointoffset));
-		float y = float(pointoffset + rand() % (MAP_DIMENSION-2*pointoffset));
-		context->fsites[i].x = x;
-		context->fsites[i].y = y;
+		sites[i].x = float(pointoffset + rand() % (MAP_DIMENSION-2*pointoffset));
+		sites[i].y = float(pointoffset + rand() % (MAP_DIMENSION-2*pointoffset));
+	}
+}
+
+void fill_symmetric_diagonal_pairs(PointF* sites, int count)
+{
+	for( int i = 0; i < count; ++i )
+	{
+		const float value = float(i / 2 + 1);
+		sites[i].x = (i & 1) ? -value : value;
+		sites[i].y = -value;
+	}
+}
+
+void populate_site_arrays(Context* context)
+{
+	for( int i = 0; i < context->count; ++i )
+	{
+		const float x = context->fsites[i].x;
+		const float y = context->fsites[i].y;
 		context->dsites[i].x = x;
 		context->dsites[i].y = y;
 		context->sitesx[i] = x;
@@ -136,6 +137,32 @@ void setup_sites(int count, Context* context)
 		context->boost_points[i] = boost::polygon::point_data<float>(x, y);
 #endif
 	}
+}
+
+void setup_sites(int count, Context* context)
+{
+	context->count = count;
+	context->fsites = new PointF[count];
+	context->dsites = new PointD[count];
+	context->sitesx = new float[count];
+	context->sitesy = new float[count];
+	context->dpoints.resize(count);
+#if defined(USE_VORONOIPP)
+	context->vpp_sites.resize(count);
+#endif
+#if defined(USE_BOOST)
+	context->boost_points.resize(count);
+#endif
+
+	context->dgmin = PointF(FLT_MAX, FLT_MAX);
+	context->dgmax = PointF(-FLT_MAX, -FLT_MAX);
+
+	const bool symmetric_diagonal_pairs = context->testname && strcmp(context->testname, "symmetric_diagonal_pairs") == 0;
+	if (symmetric_diagonal_pairs)
+		fill_symmetric_diagonal_pairs(context->fsites, count);
+	else
+		fill_random_sites(context->fsites, count);
+	populate_site_arrays(context);
 
 	context->dgmin.x -= 1;
 	context->dgmin.y -= 1;
@@ -167,7 +194,7 @@ int jc_voronoi(Context* context)
 {
 	jcv_diagram diagram = { 0 };
 	jcv_rect rect = { {context->dgmin.x, context->dgmin.y}, {context->dgmax.x, context->dgmax.y} };
-	jcv_diagram_generate(context->count, (const jcv_point*)context->fsites, &rect, &diagram );
+	jcv_diagram_generate(context->count, (const jcv_point*)context->fsites, &rect, 0, &diagram );
 
 	if( context->collectedges )
 	{
@@ -313,7 +340,8 @@ static void clip_infinite_edge( Context* context, const boost::polygon::voronoi_
 		direction.y(p2.x - p1.x);
 	} else {
 	}
-	coordinate_type side = MAP_DIMENSION;
+	coordinate_type side = 2.0 * (std::max)(context->dgmax.x - context->dgmin.x,
+										 context->dgmax.y - context->dgmin.y);
 	coordinate_type koef = side / (std::max)(fabs(direction.x()), fabs(direction.y()));
 	if (edge.vertex0() == NULL) {
 	  clipped_edge.push_back( PointF(origin.x() - direction.x() * koef, origin.y() - direction.y() * koef));
@@ -539,7 +567,7 @@ static void output_image(const char* name, Context* context)
 	}
 
 	char path[512];
-	sprintf(path, "images/voronoi_%s_%d.png", name, context->count);
+	snprintf(path, sizeof(path), "images/voronoi_%s_%d.png", name, context->count);
 	stbi_write_png(path, MAP_DIMENSION, MAP_DIMENSION, 3, data, MAP_DIMENSION*3);
 	printf("wrote %s\n", path);
 
@@ -567,7 +595,7 @@ void generate_diagram(const char* name, Context* context, SetupFunc setupfunc, F
 template<typename SetupFunc, typename Func>
 void run_test(const char* implname, const char* testname, Context* context, SetupFunc setupfunc, Func func)
 {
-	char buffer[32];
+	char buffer[64];
 	snprintf(buffer, sizeof(buffer), "%s %s", implname, testname);
 	buffer[sizeof(buffer)-1] = 0;
 
@@ -580,6 +608,8 @@ void run_test(const char* implname, const char* testname, Context* context, Setu
 
 	timeit.report(std::cout, buffer, 0.0f);
 	generate_diagram(implname, context, null_setup, func);
+	printf("# collected %zu edges across %zu cells\n",
+		   context->collectededges.size(), context->collectedcells.size());
 }
 
 int main(int argc, const char** argv)
@@ -593,12 +623,11 @@ int main(int argc, const char** argv)
 		iterations = atol(argv[2]);
 
 	Context context;
-	setup_sites(count, &context);
-	context.numiterations = iterations;
-
-	context.testname = 0;
+	context.testname = "random";
 	if( argc > 3 )
 		context.testname = argv[3];
+	setup_sites(count, &context);
+	context.numiterations = iterations;
 
 	context.generate_images = 0;
 	if( argc > 4 )

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -627,6 +627,97 @@ static inline int count_edges(jcv_graphedge* edge)
     return count;
 }
 
+static int collect_rb_inorder(jcv_halfedge* node, jcv_halfedge* nil, jcv_halfedge** nodes, int count)
+{
+    if (node == nil)
+        return count;
+    count = collect_rb_inorder(node->rb_left, nil, nodes, count);
+    nodes[count++] = node;
+    return collect_rb_inorder(node->rb_right, nil, nodes, count);
+}
+
+static int validate_rb_node(jcv_halfedge* node, jcv_halfedge* nil, jcv_halfedge* parent)
+{
+    if (node == nil)
+        return 1;
+
+    EXPECT_EQ(parent, node->rb_parent);
+    if (node->rb_red)
+    {
+        EXPECT_EQ(0, node->rb_left->rb_red);
+        EXPECT_EQ(0, node->rb_right->rb_red);
+    }
+
+    int left_height = validate_rb_node(node->rb_left, nil, node);
+    int right_height = validate_rb_node(node->rb_right, nil, node);
+    EXPECT_EQ(left_height, right_height);
+    return left_height + (node->rb_red ? 0 : 1);
+}
+
+static void validate_beachline(jcv_context_internal* internal, int expected_count)
+{
+    jcv_halfedge* nil = &internal->beachline_nil;
+    ASSERT_EQ(0, nil->rb_red);
+
+    if (internal->beachline_root != nil)
+    {
+        ASSERT_EQ(nil, internal->beachline_root->rb_parent);
+        ASSERT_EQ(0, internal->beachline_root->rb_red);
+        validate_rb_node(internal->beachline_root, nil, nil);
+    }
+
+    jcv_halfedge* tree_nodes[32];
+    int tree_count = collect_rb_inorder(internal->beachline_root, nil, tree_nodes, 0);
+    ASSERT_EQ(expected_count, tree_count);
+
+    int list_count = 0;
+    jcv_halfedge* previous = internal->beachline_start;
+    for (jcv_halfedge* node = previous->right; node != internal->beachline_end; node = node->right)
+    {
+        ASSERT_EQ(previous, node->left);
+        ASSERT_EQ(tree_nodes[list_count], node);
+        previous = node;
+        ++list_count;
+    }
+    ASSERT_EQ(previous, internal->beachline_end->left);
+    ASSERT_EQ(expected_count, list_count);
+}
+
+TEST_F(VoronoiTest, beachline_rb_insert_remove)
+{
+    jcv_context_internal internal;
+    jcv_halfedge start;
+    jcv_halfedge end;
+    jcv_halfedge nodes[16];
+    memset(&internal, 0, sizeof(internal));
+    memset(&start, 0, sizeof(start));
+    memset(&end, 0, sizeof(end));
+    memset(nodes, 0, sizeof(nodes));
+
+    jcv_beachline_init(&internal);
+    internal.beachline_start = &start;
+    internal.beachline_end = &end;
+    start.right = &end;
+    end.left = &start;
+
+    for (int i = 0; i < 16; ++i)
+    {
+        jcv_halfedge* after = (i & 1) ? &start : end.left;
+        jcv_beachline_insert_after(&internal, after, &nodes[i]);
+        validate_beachline(&internal, i + 1);
+    }
+
+    const int removal_order[] = {7, 0, 15, 8, 3, 12, 1, 14, 2, 13, 4, 11, 5, 10, 6, 9};
+    for (int i = 0; i < 16; ++i)
+    {
+        jcv_beachline_remove(&internal, &nodes[removal_order[i]]);
+        validate_beachline(&internal, 15 - i);
+    }
+    ASSERT_EQ(&internal.beachline_nil, internal.beachline_root);
+    ASSERT_EQ(&end, start.right);
+    ASSERT_EQ(&start, end.left);
+}
+
 TEST_F(VoronoiTest, fn_count_edges)
 {
     jcv_graphedge edges[4];
@@ -659,6 +750,55 @@ TEST_F(VoronoiTest, issue_missing_border_edges)
     ASSERT_EQ( site->index, 1); // Make sure we test the correct one
     ASSERT_EQ(1, is_closed_loop(site->edges));
     ASSERT_EQ(5, count_edges(site->edges));
+}
+
+TEST_F(VoronoiTest, issue48_frontier_performance_pattern)
+{
+    const int pair_count = 49999;
+    const int num_points = pair_count * 2;
+    jcv_point* points = new jcv_point[num_points];
+    for (int i = 0; i < pair_count; ++i)
+    {
+        jcv_real value = (jcv_real)(i + 1);
+        points[i * 2].x = value;
+        points[i * 2].y = -value;
+        points[i * 2 + 1].x = -value;
+        points[i * 2 + 1].y = -value;
+    }
+
+    jcv_diagram_generate(num_points, points, 0, 0, &ctx->diagram);
+    ASSERT_EQ(num_points, ctx->diagram.numsites);
+
+    const jcv_site* sites = jcv_diagram_get_sites(&ctx->diagram);
+    jcv_real tolerance = (ctx->diagram.max.x - ctx->diagram.min.x) * (jcv_real)0.00001;
+    int valid_cells = 0;
+    int closed_cells = 0;
+    for (int i = 0; i < ctx->diagram.numsites; ++i)
+    {
+        const jcv_graphedge* edge = sites[i].edges;
+        int valid = edge != 0;
+        closed_cells += edge != 0 && is_closed_loop(sites[i].edges);
+        while (valid && edge)
+        {
+            for (int point_index = 0; point_index < 2; ++point_index)
+            {
+                const jcv_point* point = &edge->pos[point_index];
+                valid = valid && isfinite((double)point->x) && isfinite((double)point->y);
+                valid = valid && point->x >= ctx->diagram.min.x - tolerance;
+                valid = valid && point->x <= ctx->diagram.max.x + tolerance;
+                valid = valid && point->y >= ctx->diagram.min.y - tolerance;
+                valid = valid && point->y <= ctx->diagram.max.y + tolerance;
+            }
+            edge = edge->next;
+        }
+        valid_cells += valid;
+    }
+    ASSERT_EQ(num_points, valid_cells);
+    // The original algorithm leaves a handful of numerically degenerate cells
+    // open for this very large coordinate range (and thousands on master).
+    ASSERT_GE(closed_cells, num_points - 16);
+
+    delete[] points;
 }
 
 


### PR DESCRIPTION
This improves the find/add/delete of half edges into the beachline.
Previously, the old implementation took 8+ seconds.

| Metric | jc_voronoi (RB beachline) | Boost.Polygon | jc_voronoi advantage |
|---|---:|---:|---:|
| Median generation time | **24.823 ms** | 44.561 ms | **1.80× faster** |
| Average generation time | **25.174 ms** | 45.049 ms | **1.79× faster** |
| Measured memory | **49.4 MB** | 84.5 MB | **42% less** |
| Allocations | **2,818** | 400,009 | **142× fewer** |


Fixes https://github.com/JCash/voronoi/issues/48