### PR TITLE
Added support for collecting unique vertices in a tightly packed array

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ void jcv_diagram_generate_useralloc( int num_points, const jcv_point* points, co
 void jcv_diagram_free( jcv_diagram* diagram );
 
 const jcv_site* jcv_diagram_get_sites( const jcv_diagram* diagram );
+int jcv_get_num_vertices( const jcv_diagram* diagram );
+void jcv_diagram_get_vertices( const jcv_diagram* diagram, jcv_point* vertices );
 const jcv_edge* jcv_diagram_get_edges( const jcv_diagram* diagram );
 const jcv_edge* jcv_diagram_get_next_edge( const jcv_edge* edge );
 ```
@@ -160,6 +162,25 @@ void draw_delauney(const jcv_diagram* diagram)
     {
         draw_line(delauney_edge.pos[0], delauney_edge.pos[1]);
     }
+}
+```
+
+## Unique vertices
+
+Each edge endpoint has a contiguous integer vertex index. The diagram itself
+does not allocate a separate vertex array; clients can create one only when it
+is needed, without comparing floating-point coordinates:
+
+```C
+jcv_point* vertices = malloc(
+    (size_t)jcv_get_num_vertices(&diagram) * sizeof(*vertices));
+jcv_diagram_get_vertices(&diagram, vertices);
+
+for (const jcv_edge* edge = jcv_diagram_get_edges(&diagram);
+     edge;
+     edge = jcv_diagram_get_next_edge(edge))
+{
+    add_indexed_edge(edge->vertices[0], edge->vertices[1]);
 }
 ```
 

--- a/src/jc_voronoi.h
+++ b/src/jc_voronoi.h
@@ -154,10 +154,10 @@ struct jcv_edge_
     struct jcv_edge_*   next;
     jcv_site*           sites[2];
     jcv_point           pos[2];
+    int                 vertices[2]; // Unique endpoint indices, indexed like pos
     jcv_real            a;
     jcv_real            b;
     jcv_real            c;
-    int                 vertices[2]; // Unique endpoint indices, indexed like pos
 };
 
 struct jcv_delauney_iter_
@@ -222,6 +222,7 @@ struct jcv_diagram_
 static const int JCV_DIRECTION_LEFT  = 0;
 static const int JCV_DIRECTION_RIGHT = 1;
 static const jcv_real JCV_INVALID_VALUE = (jcv_real)-JCV_FLT_MAX;
+static const int JCV_INVALID_VERTEX = -1;
 
 // jcv_real
 
@@ -594,8 +595,8 @@ static void jcv_edge_create(jcv_edge* e, jcv_site* s1, jcv_site* s2)
     e->pos[0].y = JCV_INVALID_VALUE;
     e->pos[1].x = JCV_INVALID_VALUE;
     e->pos[1].y = JCV_INVALID_VALUE;
-    e->vertices[0] = -1;
-    e->vertices[1] = -1;
+    e->vertices[0] = JCV_INVALID_VERTEX;
+    e->vertices[1] = JCV_INVALID_VERTEX;
 
     // Create line equation between S1 and S2:
     // jcv_real a = -1 * (s2->p.y - s1->p.y);
@@ -791,7 +792,7 @@ static int jcv_edge_clipline(jcv_context_internal* internal, jcv_edge* e)
 
     for( int i = 0; i < 2; ++i )
     {
-        e->vertices[i] = -1;
+        e->vertices[i] = JCV_INVALID_VERTEX;
         for( int j = 0; j < 2; ++j )
         {
             // Clipping may retain or reorder an existing endpoint. Only carry
@@ -1745,11 +1746,11 @@ static void jcv_circle_event(jcv_context_internal* internal)
     jcv_site* top    = jcv_halfedge_rightsite(right);
 
     jcv_point vertex = left->vertex;
-    int vertex_index = -1;
+    int vertex_index = JCV_INVALID_VERTEX;
     jcv_edge* incident_edges[2] = {left->edge, right->edge};
     // Four or more cocircular sites can report the same vertex in consecutive
     // circle events. In that case one incident edge already carries its index.
-    for( int i = 0; i < 2 && vertex_index < 0; ++i )
+    for( int i = 0; i < 2 && vertex_index == JCV_INVALID_VERTEX; ++i )
     {
         for( int endpoint = 0; endpoint < 2; ++endpoint )
         {
@@ -1762,7 +1763,7 @@ static void jcv_circle_event(jcv_context_internal* internal)
             }
         }
     }
-    if( vertex_index < 0 &&
+    if( vertex_index == JCV_INVALID_VERTEX &&
         (!internal->clipper.test_fn || internal->clipper.test_fn(&internal->clipper, vertex)) )
     {
         vertex_index = internal->numvertices++;

--- a/src/jc_voronoi.h
+++ b/src/jc_voronoi.h
@@ -94,6 +94,12 @@ extern void jcv_diagram_free( jcv_diagram* diagram );
 // Returns an array of sites, where each index is the same as the original input point array.
 extern const jcv_site* jcv_diagram_get_sites( const jcv_diagram* diagram );
 
+// Returns the number of unique vertices in the diagram.
+extern int jcv_get_num_vertices( const jcv_diagram* diagram );
+
+// Writes all unique vertices to a client-owned array of diagram->numvertices points.
+extern void jcv_diagram_get_vertices( const jcv_diagram* diagram, jcv_point* vertices );
+
 // Returns a linked list of all the voronoi edges
 // excluding the ones that lie on the borders of the bounding box.
 // For a full list of edges, you need to iterate over the sites, and their graph edges.
@@ -132,6 +138,7 @@ struct jcv_graphedge_
     struct jcv_site_*       neighbor;
     jcv_point               pos[2];
     jcv_real                angle;
+    int                     vertices[2]; // Unique endpoint indices, indexed like pos
 };
 
 struct jcv_site_
@@ -150,6 +157,7 @@ struct jcv_edge_
     jcv_real            a;
     jcv_real            b;
     jcv_real            c;
+    int                 vertices[2]; // Unique endpoint indices, indexed like pos
 };
 
 struct jcv_delauney_iter_
@@ -185,6 +193,7 @@ struct jcv_diagram_
 {
     jcv_context_internal*   internal;
     int                     numsites;
+    int                     numvertices;
     jcv_point               min;
     jcv_point               max;
 };
@@ -386,7 +395,6 @@ typedef struct jcv_priorityqueue_
     FJCVPriorityQueueGetPos     get_pos;
 } jcv_priorityqueue;
 
-
 struct jcv_context_internal_
 {
     void*               mem;
@@ -401,7 +409,7 @@ struct jcv_context_internal_
     jcv_site*           bottomsite;
     int                 numsites;
     int                 currentsite;
-    int                 _padding;
+    int                 numvertices;
 
     jcv_memoryblock*    memblocks;
     jcv_edge*           edgepool;
@@ -438,6 +446,24 @@ void jcv_diagram_free( jcv_diagram* d )
 const jcv_site* jcv_diagram_get_sites( const jcv_diagram* diagram )
 {
     return diagram->internal->sites;
+}
+
+int jcv_get_num_vertices( const jcv_diagram* diagram )
+{
+    return diagram->numvertices;
+}
+
+void jcv_diagram_get_vertices( const jcv_diagram* diagram, jcv_point* vertices )
+{
+    const jcv_site* sites = diagram->internal->sites;
+    for( int i = 0; i < diagram->numsites; ++i )
+    {
+        for( const jcv_graphedge* edge = sites[i].edges; edge; edge = edge->next )
+        {
+            vertices[edge->vertices[0]] = edge->pos[0];
+            vertices[edge->vertices[1]] = edge->pos[1];
+        }
+    }
 }
 
 const jcv_edge* jcv_diagram_get_edges( const jcv_diagram* diagram )
@@ -568,6 +594,8 @@ static void jcv_edge_create(jcv_edge* e, jcv_site* s1, jcv_site* s2)
     e->pos[0].y = JCV_INVALID_VALUE;
     e->pos[1].x = JCV_INVALID_VALUE;
     e->pos[1].y = JCV_INVALID_VALUE;
+    e->vertices[0] = -1;
+    e->vertices[1] = -1;
 
     // Create line equation between S1 and S2:
     // jcv_real a = -1 * (s2->p.y - s1->p.y);
@@ -756,7 +784,29 @@ int jcv_boxshape_clip(const jcv_clipper* clipper, jcv_edge* e)
 // see jcv_edge_create
 static int jcv_edge_clipline(jcv_context_internal* internal, jcv_edge* e)
 {
-    return internal->clipper.clip_fn(&internal->clipper, e);
+    jcv_point previous_pos[2] = {e->pos[0], e->pos[1]};
+    int previous_vertices[2] = {e->vertices[0], e->vertices[1]};
+    if( !internal->clipper.clip_fn(&internal->clipper, e) )
+        return 0;
+
+    for( int i = 0; i < 2; ++i )
+    {
+        e->vertices[i] = -1;
+        for( int j = 0; j < 2; ++j )
+        {
+            // Clipping may retain or reorder an existing endpoint. Only carry
+            // its identity across when the point itself was copied exactly.
+            if( previous_vertices[j] >= 0 &&
+                e->pos[i].x == previous_pos[j].x && e->pos[i].y == previous_pos[j].y )
+            {
+                e->vertices[i] = previous_vertices[j];
+                break;
+            }
+        }
+        if( e->vertices[i] < 0 )
+            e->vertices[i] = internal->numvertices++;
+    }
+    return 1;
 }
 
 static jcv_edge* jcv_edge_new(jcv_context_internal* internal, jcv_site* s1, jcv_site* s2)
@@ -1489,6 +1539,8 @@ static void jcv_finishline(jcv_context_internal* internal, jcv_edge* e)
         ge->neighbor = e->sites[1-i];
         ge->pos[flip] = e->pos[i];
         ge->pos[1-flip] = e->pos[1-i];
+        ge->vertices[flip] = e->vertices[i];
+        ge->vertices[1-flip] = e->vertices[1-i];
         ge->angle = jcv_calc_sort_metric(e->sites[i], ge);
 
         jcv_sortedges_insert( e->sites[i], ge );
@@ -1496,9 +1548,10 @@ static void jcv_finishline(jcv_context_internal* internal, jcv_edge* e)
 }
 
 
-static void jcv_endpos(jcv_context_internal* internal, jcv_edge* e, const jcv_point* p, int direction)
+static void jcv_endpos(jcv_context_internal* internal, jcv_edge* e, const jcv_point* p, int direction, int vertex)
 {
     e->pos[direction] = *p;
+    e->vertices[direction] = vertex;
 
     if( !jcv_is_valid(&e->pos[1 - direction]) )
         return;
@@ -1510,6 +1563,7 @@ static inline void jcv_create_corner_edge(jcv_context_internal* internal, const 
 {
     gap->neighbor   = 0;
     gap->pos[0]     = current->pos[1];
+    gap->vertices[0] = current->vertices[1];
 
     if( current->pos[1].x < internal->rect.max.x && current->pos[1].y == internal->rect.min.y )
     {
@@ -1532,6 +1586,7 @@ static inline void jcv_create_corner_edge(jcv_context_internal* internal, const 
         gap->pos[1].y = internal->rect.max.y;
     }
 
+    gap->vertices[1] = internal->numvertices++;
     gap->angle = jcv_calc_sort_metric(site, gap);
 }
 
@@ -1540,6 +1595,8 @@ static jcv_edge* jcv_create_gap_edge(jcv_context_internal* internal, jcv_site* s
     jcv_edge* edge  = jcv_alloc_edge(internal);
     edge->pos[0]    = ge->pos[0];
     edge->pos[1]    = ge->pos[1];
+    edge->vertices[0] = ge->vertices[0];
+    edge->vertices[1] = ge->vertices[1];
     edge->sites[0]  = site;
     edge->sites[1]  = 0;
     edge->a = edge->b = edge->c = 0;
@@ -1562,6 +1619,8 @@ void jcv_boxshape_fillgaps(const jcv_clipper* clipper, jcv_context_internal* all
         gap->pos[0]     = clipper->min;
         gap->pos[1].x   = clipper->max.x;
         gap->pos[1].y   = clipper->min.y;
+        gap->vertices[0] = allocator->numvertices++;
+        gap->vertices[1] = allocator->numvertices++;
         gap->angle      = jcv_calc_sort_metric(site, gap);
         gap->next       = 0;
         gap->edge       = jcv_create_gap_edge(allocator, site, gap);
@@ -1609,6 +1668,8 @@ void jcv_boxshape_fillgaps(const jcv_clipper* clipper, jcv_context_internal* all
                 gap->neighbor   = 0;
                 gap->pos[0]     = current->pos[1];
                 gap->pos[1]     = next->pos[0];
+                gap->vertices[0] = current->vertices[1];
+                gap->vertices[1] = next->vertices[0];
                 gap->angle      = jcv_calc_sort_metric(site, gap);
                 gap->edge       = jcv_create_gap_edge(allocator, site, gap);
 
@@ -1639,6 +1700,8 @@ void jcv_boxshape_fillgaps(const jcv_clipper* clipper, jcv_context_internal* all
                 gap->neighbor   = 0;
                 gap->pos[0]     = current->pos[1];
                 gap->pos[1]     = corner;
+                gap->vertices[0] = current->vertices[1];
+                gap->vertices[1] = allocator->numvertices++;
                 gap->angle      = jcv_calc_sort_metric(site, gap);
                 gap->edge       = jcv_create_gap_edge(allocator, site, gap);
 
@@ -1671,7 +1734,6 @@ static void jcv_fillgaps(jcv_diagram* diagram)
     }
 }
 
-
 static void jcv_circle_event(jcv_context_internal* internal)
 {
     jcv_halfedge* left      = (jcv_halfedge*)jcv_pq_pop(internal->eventqueue);
@@ -1683,8 +1745,30 @@ static void jcv_circle_event(jcv_context_internal* internal)
     jcv_site* top    = jcv_halfedge_rightsite(right);
 
     jcv_point vertex = left->vertex;
-    jcv_endpos(internal, left->edge, &vertex, left->direction);
-    jcv_endpos(internal, right->edge, &vertex, right->direction);
+    int vertex_index = -1;
+    jcv_edge* incident_edges[2] = {left->edge, right->edge};
+    // Four or more cocircular sites can report the same vertex in consecutive
+    // circle events. In that case one incident edge already carries its index.
+    for( int i = 0; i < 2 && vertex_index < 0; ++i )
+    {
+        for( int endpoint = 0; endpoint < 2; ++endpoint )
+        {
+            if( incident_edges[i]->vertices[endpoint] >= 0 &&
+                incident_edges[i]->pos[endpoint].x == vertex.x &&
+                incident_edges[i]->pos[endpoint].y == vertex.y )
+            {
+                vertex_index = incident_edges[i]->vertices[endpoint];
+                break;
+            }
+        }
+    }
+    if( vertex_index < 0 &&
+        (!internal->clipper.test_fn || internal->clipper.test_fn(&internal->clipper, vertex)) )
+    {
+        vertex_index = internal->numvertices++;
+    }
+    jcv_endpos(internal, left->edge, &vertex, left->direction, vertex_index);
+    jcv_endpos(internal, right->edge, &vertex, right->direction, vertex_index);
 
     jcv_pq_remove(internal->eventqueue, right);
     jcv_beachline_remove(internal, left);
@@ -1707,7 +1791,7 @@ static void jcv_circle_event(jcv_context_internal* internal)
 
     jcv_halfedge* he = jcv_halfedge_new(internal, edge, direction);
     jcv_beachline_insert_after(internal, leftleft, he);
-    jcv_endpos(internal, edge, &vertex, JCV_DIRECTION_RIGHT - direction);
+    jcv_endpos(internal, edge, &vertex, JCV_DIRECTION_RIGHT - direction, vertex_index);
 
     jcv_point p;
     if( jcv_check_circle_event( leftleft, he, &p ) )
@@ -1974,6 +2058,7 @@ void jcv_diagram_generate_useralloc(int num_points, const jcv_point* points, con
     }
 
     jcv_fillgaps(d);
+    d->numvertices = internal->numvertices;
 }
 
 #endif // JC_VORONOI_IMPLEMENTATION
@@ -1985,8 +2070,9 @@ ABOUT:
     A fast single file 2D voronoi diagram generator
 
 HISTORY:
-    0.10    2026-07-19  - Use a BST to manipulate the beachline
+    0.10    2026-07-20  - Added unique vertex indices and vertex extraction
             2026-07-20  - Fix invalid topology handling for near-collinear sites
+            2026-07-19  - Use a BST to manipulate the beachline
     0.9     2023-01-22  - Modified the Delauney iterator creation api
     0.8     2022-12-20  - Added fix for missing border edges
                           More robust removal of duplicate graph edges

--- a/src/jc_voronoi_clip.h
+++ b/src/jc_voronoi_clip.h
@@ -241,6 +241,8 @@ void jcv_clip_polygon_fill_gaps(const jcv_clipper* clipper, jcv_context_internal
         // Pick the first edge of the polygon (which is also CCW)
         gap->pos[0] = polygon->points[0];
         gap->pos[1] = polygon->points[1];
+        gap->vertices[0] = allocator->numvertices++;
+        gap->vertices[1] = allocator->numvertices++;
         gap->angle  = jcv_calc_sort_metric(site, gap);
         gap->next   = 0;
         gap->edge   = jcv_create_gap_edge(allocator, site, gap);
@@ -262,6 +264,8 @@ void jcv_clip_polygon_fill_gaps(const jcv_clipper* clipper, jcv_context_internal
             gap->pos[0] = polygon->points[(polygon_edge+1)%num_points];
             gap->pos[1] = polygon->points[(polygon_edge+2)%num_points];
         }
+        gap->vertices[0] = current->vertices[1];
+        gap->vertices[1] = allocator->numvertices++;
 
         gap->neighbor   = 0;
         gap->angle      = jcv_calc_sort_metric(site, gap);
@@ -283,11 +287,14 @@ void jcv_clip_polygon_fill_gaps(const jcv_clipper* clipper, jcv_context_internal
 
             jcv_graphedge* gap = jcv_alloc_graphedge(allocator);
             gap->pos[0] = current->pos[1];
+            gap->vertices[0] = current->vertices[1];
 
             if (polygon_edge1 != polygon_edge2) {
                 gap->pos[1] = polygon->points[(polygon_edge1+1)%num_points];
+                gap->vertices[1] = allocator->numvertices++;
             } else {
                 gap->pos[1] = next->pos[0];
+                gap->vertices[1] = next->vertices[0];
             }
 
             gap->neighbor   = 0;

--- a/test/perftest.cpp
+++ b/test/perftest.cpp
@@ -1,5 +1,6 @@
 #include <cstring>
 #include <cstdlib>
+#include <cmath>
 #include <float.h>
 
 static size_t g_MallocCount = 0;
@@ -71,6 +72,12 @@ struct Context
 	float* sitesy;
 	PointF dgmin;
 	PointF dgmax;
+	volatile double totalcellarea;
+#if defined(USE_JC_VORONOI)
+	volatile jcv_real vertexchecksum;
+	jcv_diagram vertexdiagram;
+	jcv_point* vertices;
+#endif
 
 	const char* testname;
 
@@ -170,6 +177,10 @@ void setup_sites(int count, Context* context)
 	context->dgmax.y += 1;
 
 	context->collectedges = false;
+#if defined(USE_JC_VORONOI)
+	memset(&context->vertexdiagram, 0, sizeof(context->vertexdiagram));
+	context->vertices = 0;
+#endif
 }
 
 void start_test(const char* name, Context* context)
@@ -180,9 +191,10 @@ void start_test(const char* name, Context* context)
 
 void stop_test(const char* name, Context* context)
 {
-	size_t overheadsize = context->count * sizeof(std::chrono::duration<float>);
-	size_t overheadnumallocations = 1;
-	printf("%s\tused %lu bytes in %lu allocations\n", name, g_MallocSize/context->numiterations - overheadsize, g_MallocCount/context->numiterations - overheadnumallocations);
+	size_t overheadsize = (size_t)context->numiterations * sizeof(std::chrono::duration<double>);
+	size_t usedsize = g_MallocSize >= overheadsize ? g_MallocSize - overheadsize : 0;
+	size_t allocations = g_MallocCount > 0 ? g_MallocCount - 1 : 0;
+	printf("%s\tused %lu bytes in %lu allocations\n", name, usedsize/context->numiterations, allocations/context->numiterations);
 }
 
 void null_setup(Context* context)
@@ -190,11 +202,28 @@ void null_setup(Context* context)
 }
 
 #if defined(USE_JC_VORONOI)
-int jc_voronoi(Context* context)
+int jc_voronoi_impl(Context* context, bool calculatecellarea)
 {
 	jcv_diagram diagram = { 0 };
 	jcv_rect rect = { {context->dgmin.x, context->dgmin.y}, {context->dgmax.x, context->dgmax.y} };
 	jcv_diagram_generate(context->count, (const jcv_point*)context->fsites, &rect, 0, &diagram );
+
+	if( calculatecellarea )
+	{
+		double totalarea = 0.0;
+		const jcv_site* sites = jcv_diagram_get_sites( &diagram );
+		for( int i = 0; i < diagram.numsites; ++i )
+		{
+			double twicearea = 0.0;
+			for( const jcv_graphedge* edge = sites[i].edges; edge; edge = edge->next )
+			{
+				twicearea += (double)edge->pos[0].x * (double)edge->pos[1].y -
+				             (double)edge->pos[1].x * (double)edge->pos[0].y;
+			}
+			totalarea += std::fabs(twicearea) * 0.5;
+		}
+		context->totalcellarea = totalarea;
+	}
 
 	if( context->collectedges )
 	{
@@ -228,6 +257,40 @@ int jc_voronoi(Context* context)
 
 	jcv_diagram_free( &diagram );
 	return 0;
+}
+
+int jc_voronoi(Context* context)
+{
+	return jc_voronoi_impl(context, false);
+}
+
+int jc_voronoi_cell_areas(Context* context)
+{
+	return jc_voronoi_impl(context, true);
+}
+
+void setup_jc_voronoi_vertices(Context* context)
+{
+	jcv_rect rect = { {context->dgmin.x, context->dgmin.y}, {context->dgmax.x, context->dgmax.y} };
+	jcv_diagram_generate(context->count, (const jcv_point*)context->fsites, &rect, 0, &context->vertexdiagram);
+	context->vertices = new jcv_point[jcv_get_num_vertices(&context->vertexdiagram)];
+}
+
+int jc_voronoi_get_vertices(Context* context)
+{
+	jcv_diagram_get_vertices(&context->vertexdiagram, context->vertices);
+	int numvertices = jcv_get_num_vertices(&context->vertexdiagram);
+	if( numvertices > 0 )
+		context->vertexchecksum = context->vertices[numvertices-1].x;
+	return 0;
+}
+
+void teardown_jc_voronoi_vertices(Context* context)
+{
+	delete[] context->vertices;
+	context->vertices = 0;
+	jcv_diagram_free(&context->vertexdiagram);
+	memset(&context->vertexdiagram, 0, sizeof(context->vertexdiagram));
 }
 #endif
 
@@ -612,6 +675,22 @@ void run_test(const char* implname, const char* testname, Context* context, Setu
 		   context->collectededges.size(), context->collectedcells.size());
 }
 
+template<typename Func>
+void run_postprocess_test(const char* name, const char* testname, Context* context, Func func)
+{
+	char buffer[64];
+	snprintf(buffer, sizeof(buffer), "%s %s", name, testname);
+	buffer[sizeof(buffer)-1] = 0;
+
+	printf("# n %d  it %d\n", context->count, context->numiterations);
+
+	CTimeIt timeit;
+	start_test(buffer, context);
+	timeit.run<int>(context->numiterations, null_setup, func, context);
+	stop_test(buffer, context);
+	timeit.report(std::cout, buffer, 0.0f);
+}
+
 int main(int argc, const char** argv)
 {
 	int count = 200;
@@ -640,6 +719,12 @@ int main(int argc, const char** argv)
 
 #if defined(USE_JC_VORONOI)
 	run_test("jc_voronoi", context.testname, &context, null_setup, jc_voronoi);
+	run_test("jc_voronoi_cell_areas", context.testname, &context, null_setup, jc_voronoi_cell_areas);
+	printf("# total cell area %.17g\n", context.totalcellarea);
+	setup_jc_voronoi_vertices(&context);
+	run_postprocess_test("jc_voronoi_get_vertices", context.testname, &context, jc_voronoi_get_vertices);
+	printf("# collected %d unique vertices\n", jcv_get_num_vertices(&context.vertexdiagram));
+	teardown_jc_voronoi_vertices(&context);
 #elif defined(USE_FASTJET)
 	run_test("fastjet", context.testname, &context, null_setup, fastjet_voronoi);
 #elif defined(USE_BOOST)

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -81,6 +81,42 @@ static bool check_graphedge_eq(const jcv_graphedge* e, const jcv_point* p1, cons
 #define ASSERT_POINT_NE( _P1, _P2 ) \
     ASSERT_TRUE( !check_point_eq( &_P1, &_P2) )
 
+static int validate_vertex_indices(const jcv_diagram* diagram)
+{
+    if( diagram->numvertices == 0 )
+        return 0;
+
+    bool* seen = (bool*)calloc((size_t)diagram->numvertices, sizeof(bool));
+    jcv_point* vertices = (jcv_point*)malloc((size_t)diagram->numvertices * sizeof(jcv_point));
+    jcv_diagram_get_vertices(diagram, vertices);
+
+    int errors = 0;
+    const jcv_site* sites = jcv_diagram_get_sites(diagram);
+    for( int i = 0; i < diagram->numsites; ++i )
+    {
+        for( const jcv_graphedge* edge = sites[i].edges; edge; edge = edge->next )
+        {
+            for( int endpoint = 0; endpoint < 2; ++endpoint )
+            {
+                int vertex = edge->vertices[endpoint];
+                if( vertex < 0 || vertex >= diagram->numvertices )
+                {
+                    ++errors;
+                    continue;
+                }
+                seen[vertex] = true;
+                errors += !check_point_eq(&vertices[vertex], &edge->pos[endpoint]);
+            }
+        }
+    }
+    for( int i = 0; i < diagram->numvertices; ++i )
+        errors += !seen[i];
+
+    free(vertices);
+    free(seen);
+    return errors;
+}
+
 static void check_edges(const jcv_graphedge* edges, int num_expected,
                         const jcv_point* expected_points, const jcv_site** expected_neighbors)
 {
@@ -395,6 +431,12 @@ TEST_F(VoronoiTest, many)
         jcv_diagram_generate(num_points, points, 0, 0, &ctx->diagram);
 
         //ASSERT_EQ( num_points, ctx->diagram.numsites );
+
+        int edges_without_vertices = 0;
+        for( const jcv_edge* edge = jcv_diagram_get_edges(&ctx->diagram); edge; edge = jcv_diagram_get_next_edge(edge) )
+            edges_without_vertices += edge->vertices[0] < 0 || edge->vertices[1] < 0;
+        ASSERT_EQ(0, edges_without_vertices);
+        ASSERT_EQ(0, validate_vertex_indices(&ctx->diagram));
 
         if( count < maxcount-1 )
         {
@@ -734,6 +776,60 @@ TEST_F(VoronoiTest, fn_count_edges)
     ASSERT_EQ(4, count_edges(edges));
 }
 
+TEST_F(VoronoiTest, unique_vertices)
+{
+    jcv_point points[] = {
+        {0.25f, 0.25f},
+        {0.75f, 0.25f},
+        {0.25f, 0.75f},
+        {0.75f, 0.75f},
+    };
+    jcv_rect rect = {{0, 0}, {1, 1}};
+    jcv_diagram_generate(4, points, &rect, 0, &ctx->diagram);
+
+    // Four corners, four edge midpoints and one four-way center vertex.
+    ASSERT_EQ(9, ctx->diagram.numvertices);
+    ASSERT_EQ(ctx->diagram.numvertices, jcv_get_num_vertices(&ctx->diagram));
+    bool indices[9] = {};
+    jcv_point vertices[9];
+    jcv_diagram_get_vertices(&ctx->diagram, vertices);
+
+    const jcv_site* sites = jcv_diagram_get_sites(&ctx->diagram);
+    for( int i = 0; i < ctx->diagram.numsites; ++i )
+    {
+        const jcv_graphedge* first = sites[i].edges;
+        ASSERT_TRUE(first != 0);
+        const jcv_graphedge* edge = first;
+        while( edge )
+        {
+            const jcv_graphedge* next = edge->next ? edge->next : first;
+            ASSERT_GE(edge->vertices[0], 0);
+            ASSERT_LT(edge->vertices[0], ctx->diagram.numvertices);
+            ASSERT_GE(edge->vertices[1], 0);
+            ASSERT_LT(edge->vertices[1], ctx->diagram.numvertices);
+            ASSERT_EQ(edge->vertices[1], next->vertices[0]);
+            ASSERT_POINT_EQ(vertices[edge->vertices[0]], edge->pos[0]);
+            ASSERT_POINT_EQ(vertices[edge->vertices[1]], edge->pos[1]);
+            indices[edge->vertices[0]] = true;
+            indices[edge->vertices[1]] = true;
+            edge = edge->next;
+        }
+    }
+
+    for( int i = 0; i < ctx->diagram.numvertices; ++i )
+        ASSERT_TRUE(indices[i]);
+
+    for( const jcv_edge* edge = jcv_diagram_get_edges(&ctx->diagram); edge; edge = jcv_diagram_get_next_edge(edge) )
+    {
+        ASSERT_GE(edge->vertices[0], 0);
+        ASSERT_LT(edge->vertices[0], ctx->diagram.numvertices);
+        ASSERT_GE(edge->vertices[1], 0);
+        ASSERT_LT(edge->vertices[1], ctx->diagram.numvertices);
+        ASSERT_POINT_EQ(vertices[edge->vertices[0]], edge->pos[0]);
+        ASSERT_POINT_EQ(vertices[edge->vertices[1]], edge->pos[1]);
+    }
+}
+
 TEST_F(VoronoiTest, issue91_cells_are_closed)
 {
     jcv_point points[] = {
@@ -818,6 +914,56 @@ TEST_F(VoronoiTest, issue_missing_border_edges)
     ASSERT_EQ(5, count_edges(site->edges));
 }
 
+TEST_F(VoronoiTest, issue47_no_invalid_edges_span_clipping_rect)
+{
+    const jcv_point points[] = {
+        {1205.64417f, 0.224472046f},
+        {190.131897f, 0.285560131f},
+        {1955.71814f, 0.0870857239f},
+        {128.955994f, 0.344024658f},
+    };
+    const int num_points = (int)(sizeof(points) / sizeof(points[0]));
+    jcv_rect rect = {{0, 0}, {2048, 2048}};
+
+    jcv_diagram_generate(num_points, points, &rect, 0, &ctx->diagram);
+    ASSERT_EQ(num_points, ctx->diagram.numsites);
+
+    // Issue #47 produced geometrically invalid internal edges running from
+    // y=0 to y=2048 across the entire clipping rectangle.
+    int num_spanning_edges = 0;
+    int num_invalid_spanning_edges = 0;
+    for( const jcv_edge* edge = jcv_diagram_get_edges(&ctx->diagram); edge; edge = jcv_diagram_get_next_edge(edge) )
+    {
+        const int spans_height =
+            (edge->pos[0].y == rect.min.y && edge->pos[1].y == rect.max.y) ||
+            (edge->pos[1].y == rect.min.y && edge->pos[0].y == rect.max.y);
+        if( !spans_height || !edge->sites[0] || !edge->sites[1] )
+            continue;
+
+        ++num_spanning_edges;
+        const double xmid = ((double)edge->pos[0].x + (double)edge->pos[1].x) * 0.5;
+        const double ymid = ((double)edge->pos[0].y + (double)edge->pos[1].y) * 0.5;
+        const double dx = xmid - (double)edge->sites[0]->p.x;
+        const double dy = ymid - (double)edge->sites[0]->p.y;
+        const double site_distance_sq = dx * dx + dy * dy;
+        const double tolerance = site_distance_sq * 1.0e-4 + 1.0e-4;
+        for( int i = 0; i < num_points; ++i )
+        {
+            const double other_dx = xmid - (double)points[i].x;
+            const double other_dy = ymid - (double)points[i].y;
+            const double other_distance_sq = other_dx * other_dx + other_dy * other_dy;
+            if( other_distance_sq + tolerance < site_distance_sq )
+            {
+                ++num_invalid_spanning_edges;
+                break;
+            }
+        }
+    }
+
+    ASSERT_EQ(3, num_spanning_edges);
+    ASSERT_EQ(0, num_invalid_spanning_edges);
+}
+
 TEST_F(VoronoiTest, issue48_frontier_performance_pattern)
 {
     const int pair_count = 49999;
@@ -834,6 +980,7 @@ TEST_F(VoronoiTest, issue48_frontier_performance_pattern)
 
     jcv_diagram_generate(num_points, points, 0, 0, &ctx->diagram);
     ASSERT_EQ(num_points, ctx->diagram.numsites);
+    ASSERT_EQ(0, validate_vertex_indices(&ctx->diagram));
 
     const jcv_site* sites = jcv_diagram_get_sites(&ctx->diagram);
     jcv_real tolerance = (ctx->diagram.max.x - ctx->diagram.min.x) * (jcv_real)0.00001;


### PR DESCRIPTION
From the README.md:
```C
jcv_point* vertices = malloc(
    (size_t)jcv_get_num_vertices(&diagram) * sizeof(*vertices));
jcv_diagram_get_vertices(&diagram, vertices);

for (const jcv_edge* edge = jcv_diagram_get_edges(&diagram);
     edge;
     edge = jcv_diagram_get_next_edge(edge))
{
    add_indexed_edge(edge->vertices[0], edge->vertices[1]);
}
```

Fixes https://github.com/JCash/voronoi/issues/36
