### PR TITLE
Add CMake support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,19 @@ name: Build
 on: [push, pull_request]
 
 jobs:
+  build-cmake:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure CMake
+        run: cmake -S . -B build-cmake -DJC_VORONOI_BUILD_EXAMPLES=ON -DJC_VORONOI_BUILD_TESTS=ON
+      - name: Build CMake targets
+        run: cmake --build build-cmake --parallel
+      - name: Run CMake tests
+        run: ctest --test-dir build-cmake --output-on-failure
+      - name: Verify CMake install
+        run: cmake --install build-cmake --prefix build-cmake/install
+
   build-wasm:
     runs-on: ubuntu-latest
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,86 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(jc_voronoi VERSION 0.10.0 LANGUAGES C)
+
+include(GNUInstallDirs)
+
+add_library(jc_voronoi INTERFACE)
+add_library(jc_voronoi::jc_voronoi ALIAS jc_voronoi)
+
+target_compile_features(jc_voronoi INTERFACE c_std_99)
+target_include_directories(
+    jc_voronoi
+    INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+if(NOT WIN32)
+    target_link_libraries(jc_voronoi INTERFACE m)
+endif()
+
+option(JC_VORONOI_BUILD_EXAMPLES "Build the example programs" OFF)
+option(JC_VORONOI_BUILD_TESTS "Build and register the test programs" OFF)
+
+if(JC_VORONOI_BUILD_EXAMPLES)
+    add_executable(jc_voronoi_main src/main.c src/stb_wrapper.c)
+    target_link_libraries(jc_voronoi_main PRIVATE jc_voronoi::jc_voronoi)
+
+    add_executable(jc_voronoi_simple src/examples/simple.c)
+    target_link_libraries(jc_voronoi_simple PRIVATE jc_voronoi::jc_voronoi)
+endif()
+
+if(JC_VORONOI_BUILD_TESTS)
+    enable_language(CXX)
+    enable_testing()
+
+    function(jc_voronoi_add_test target_name)
+        add_executable(${target_name} test/test.cpp)
+        target_compile_features(${target_name} PRIVATE cxx_std_11)
+        target_include_directories(${target_name} PRIVATE test)
+        target_link_libraries(${target_name} PRIVATE jc_voronoi::jc_voronoi)
+        add_test(NAME ${target_name} COMMAND ${target_name})
+    endfunction()
+
+    jc_voronoi_add_test(jc_voronoi_test)
+    jc_voronoi_add_test(jc_voronoi_test_double)
+    target_compile_definitions(
+        jc_voronoi_test_double
+        PRIVATE
+            TEST_USE_DOUBLE
+            JCV_USE_DOUBLE=1
+            JCV_REAL_TYPE=double
+            JCV_ATAN2=atan2
+            JCV_SQRT=sqrt
+            JCV_REAL_TYPE_EPSILON=DBL_EPSILON
+    )
+endif()
+
+install(TARGETS jc_voronoi EXPORT jc_voronoiTargets)
+install(
+    FILES src/jc_voronoi.h src/jc_voronoi_clip.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+install(
+    EXPORT jc_voronoiTargets
+    FILE jc_voronoiTargets.cmake
+    NAMESPACE jc_voronoi::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/jc_voronoi
+)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+    cmake/jc_voronoiConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/jc_voronoiConfig.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/jc_voronoi
+)
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/jc_voronoiConfigVersion.cmake
+    COMPATIBILITY SameMajorVersion
+)
+install(
+    FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/jc_voronoiConfig.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/jc_voronoiConfigVersion.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/jc_voronoi
+)

--- a/README.md
+++ b/README.md
@@ -79,6 +79,27 @@ one C or C++ translation unit:
 Other translation units should include `jc_voronoi.h` without defining
 `JC_VORONOI_IMPLEMENTATION`.
 
+## CMake
+
+When this repository is added with `add_subdirectory` or `FetchContent`, link
+the header-only target to your application:
+
+```cmake
+target_link_libraries(your_app PRIVATE jc_voronoi::jc_voronoi)
+```
+
+The default CMake build does not produce a library file because `jc_voronoi`
+is header-only. To build the bundled example programs and tests, configure with:
+
+```sh
+cmake -S . -B build -DJC_VORONOI_BUILD_EXAMPLES=ON -DJC_VORONOI_BUILD_TESTS=ON
+cmake --build build
+ctest --test-dir build
+```
+
+The project can also be installed. An installed copy can be consumed with
+`find_package(jc_voronoi CONFIG REQUIRED)` and the same namespaced target.
+
 ## macOS
 
 Build and run the example (assumes `clang` is installed):

--- a/cmake/jc_voronoiConfig.cmake.in
+++ b/cmake/jc_voronoiConfig.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/jc_voronoiTargets.cmake")
+
+check_required_components(jc_voronoi)


### PR DESCRIPTION
## Summary

- Add a header-only CMake target with examples, tests, and install/package configuration.
- Document CMake usage and installation in the README.
- Validate CMake configuration, builds, tests, and installation in GitHub Actions.

## Testing

- CMake examples and test targets are built in CI.
- CTest runs with failure output enabled.
- CMake installation is verified in CI.